### PR TITLE
SLING-9841: JCR ContentLoader Runmode Support

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentLoaderService.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentLoaderService.java
@@ -94,6 +94,9 @@ public class ContentLoaderService implements SynchronousBundleListener, BundleHe
     @Reference
     private ContentReaderWhiteboard contentReaderWhiteboard;
 
+    @Reference
+    private SlingSettingsService slingSettings;
+
     /**
      * The initial content loader which is called to load initial content up
      * into the repository when the providing bundle is installed.
@@ -222,7 +225,7 @@ public class ContentLoaderService implements SynchronousBundleListener, BundleHe
     @Activate
     protected synchronized void activate(BundleContext bundleContext) {
         this.slingId = this.settingsService.getSlingId();
-        this.bundleContentLoader = new BundleContentLoader(this, contentReaderWhiteboard);
+        this.bundleContentLoader = new BundleContentLoader(this, contentReaderWhiteboard, slingSettings.getRunModes());
 
         bundleContext.addBundleListener(this);
 

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/PathEntry.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/PathEntry.java
@@ -93,6 +93,14 @@ public class PathEntry extends ImportOptions {
      */
     public static final String IGNORE_CONTENT_READERS_DIRECTIVE = "ignoreImportProviders";
 
+    /**
+     * If the content should be skipped with a particular runmode. By
+     * default this will be an empty string which means the content will be
+     * installed regardless of the runmode
+     * @since 2.4.0
+     */
+    public static final String SKIP_RUNMODE = "skipRunmode";
+
     private final boolean propertyMerge;
     
     private final boolean nodeMerge;
@@ -105,6 +113,9 @@ public class PathEntry extends ImportOptions {
 
     /** Should existing content properties be overwritten? */
     private final boolean overwriteProperties;
+
+    /** The content at the path will be skipped for this runmode */
+    private final String skipRunmode;
 
     /** Should existing content be uninstalled? */
     private final boolean uninstall;
@@ -233,6 +244,9 @@ public class PathEntry extends ImportOptions {
         }
 
         // workspace directive
+        this.skipRunmode = entry.getDirectiveValue(SKIP_RUNMODE);
+
+        // workspace directive
         final String workspaceValue = entry.getDirectiveValue(WORKSPACE_DIRECTIVE);
         if (pathValue != null) {
             this.workspace = workspaceValue;
@@ -293,6 +307,10 @@ public class PathEntry extends ImportOptions {
         return this.ignoreContentReaders.contains(extension);
     }
 
+    public String getSkipRunmode(){
+        return this.skipRunmode;
+    }
+
     public String getTarget() {
         return target;
     }
@@ -301,11 +319,9 @@ public class PathEntry extends ImportOptions {
         return workspace;
     }
 
-
     public boolean isPropertyMerge() {
         return this.propertyMerge;
     }
-
 
     public boolean isMerge() {
         return this.nodeMerge;

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
@@ -21,7 +21,10 @@ package org.apache.sling.jcr.contentloader.internal;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+
+import java.util.Collections;
 
 import javax.jcr.Session;
 
@@ -60,7 +63,7 @@ public class BundleContentLoaderTest {
 
         ContentReaderWhiteboard whiteboard = context.getService(ContentReaderWhiteboard.class);
 
-        contentLoader = new BundleContentLoader(bundleHelper, whiteboard);
+        contentLoader = new BundleContentLoader(bundleHelper, whiteboard, Collections.singleton("seed"));
     }
 
 
@@ -75,6 +78,31 @@ public class BundleContentLoaderTest {
 
         assertThat("Resource was not imported", imported, notNullValue());
         assertThat("sling:resourceType was not properly set", imported.getResourceType(), equalTo("sling:Folder"));
+    }
+
+
+    @Test
+    public void skippedRunmode() throws Exception {
+        Bundle mockBundle = newBundleWithInitialContent("SLING-INF/libs/app/skipped;path:=/libs/app/skipped;skipRunmode:=seed");
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+        Resource imported = context.resourceResolver().getResource("/libs/app/skipped");
+        assertThat("Import should have been skipped", imported, nullValue());
+    }
+
+    @Test
+    public void passedRunmode() throws Exception {
+        Bundle mockBundle = newBundleWithInitialContent("SLING-INF/libs/app/passed;path:=/libs/app/passed;skipRunmode:=runtime");
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+        Resource imported = context.resourceResolver().getResource("/libs/app/passed");
+        assertThat("Resource was not imported", imported, notNullValue());
+    }
+
+    @Test
+    public void emptyRunmode() throws Exception {
+        Bundle mockBundle = newBundleWithInitialContent("SLING-INF/libs/app/empty;path:=/libs/app/empty");
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+        Resource imported = context.resourceResolver().getResource("/libs/app/empty");
+        assertThat("Resource was not imported", imported, notNullValue());
     }
 
     @Test

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
@@ -98,8 +98,17 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void emptyRunmode() throws Exception {
+    public void nullRunmode() throws Exception {
         Bundle mockBundle = newBundleWithInitialContent("SLING-INF/libs/app/empty;path:=/libs/app/empty");
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+        Resource imported = context.resourceResolver().getResource("/libs/app/empty");
+        assertThat("Resource was not imported", imported, notNullValue());
+    }
+
+
+    @Test
+    public void emptyRunmode() throws Exception {
+        Bundle mockBundle = newBundleWithInitialContent("SLING-INF/libs/app/empty;path:=/libs/app/empty;skipRunmode:=");
         contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
         Resource imported = context.resourceResolver().getResource("/libs/app/empty");
         assertThat("Resource was not imported", imported, notNullValue());


### PR DESCRIPTION
Adding support for skipping the loading of a path when a runmode matches