### PR TITLE
Fixes SLING-9844: Import Breaks on Complex Node Structures	

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
@@ -455,7 +455,6 @@ public class DefaultContentCreator implements ContentCreator {
         cleanUpNode(node);
         // resolve REFERENCE property values pointing to this node
         resolveReferences(node);
-        node.getSession().save();
     }
 
     private void cleanUpNode(Node node) throws RepositoryException {


### PR DESCRIPTION
Fixes [SLING-9844](https://issues.apache.org/jira/browse/SLING-9844)

Removing the node save to fix the issue where import breaks on complex node structures