### PR TITLE
SLING-11203: Introduce requireImportProvider directive

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/ImportOptions.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/ImportOptions.java
@@ -18,6 +18,9 @@
  */
 package org.apache.sling.jcr.contentloader;
 
+import java.util.Collection;
+
+import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ConsumerType;
 
 /**
@@ -85,5 +88,16 @@ public abstract class ImportOptions {
 	 * @return true to ignore the reader, false otherwise
 	 */
 	public abstract boolean isIgnoredImportProvider(String extension);
+
+    /**
+     * Check if the given entry name should require a matching registered 
+     * import provider.
+     *
+     * @param name the entry name to check
+     * @param defaultImportProviderRequired the default set to consider 
+     *          when no requireImportProviders directive is supplied
+     * @return true to require an import provider, false otherwise
+     */
+    public abstract boolean isImportProviderRequired(@NotNull String name, @NotNull Collection<String> defaultImportProviderRequired);
 
 }

--- a/src/main/java/org/apache/sling/jcr/contentloader/PathEntry.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/PathEntry.java
@@ -422,16 +422,16 @@ public class PathEntry extends ImportOptions {
 
         // a filter to check if the name ends with the suffix and is not
         //  listed in the ignored import provider set
-        Predicate<String> endsWithExtAndNotAnIgnoredImportProvider = ext -> {
-                   // longer than file ext
-            return name.length() > ext.length() && 
-                   // ends with file ext
-                   name.endsWith(ext) &&  
-                   // dot before the file ext
-                   '.' == name.charAt(name.length() - ext.length() - 1) &&
-                   // and not one of the ignored providers
-                   !isIgnoredImportProvider(ext);
-        };
+        Predicate<String> endsWithExtAndNotAnIgnoredImportProvider = ext ->
+                // longer than file ext
+                name.length() > ext.length() && 
+                // ends with file ext
+                name.endsWith(ext) &&  
+                // dot before the file ext
+                '.' == name.charAt(name.length() - ext.length() - 1) &&
+                // and not one of the ignored providers
+                !isIgnoredImportProvider(ext);
+
         if (this.requireContentReaders.isEmpty()) {
             // no directive was supplied, so fallback to the default collection
             required = defaultImportProviderRequired.stream()

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderConfiguration.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderConfiguration.java
@@ -18,6 +18,10 @@
  */
 package org.apache.sling.jcr.contentloader.internal;
 
+import org.apache.sling.jcr.contentloader.internal.readers.JsonReader;
+import org.apache.sling.jcr.contentloader.internal.readers.OrderedJsonReader;
+import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
+import org.apache.sling.jcr.contentloader.internal.readers.ZipReader;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
@@ -29,4 +33,14 @@ public @interface BundleContentLoaderConfiguration {
 
     @AttributeDefinition(name = "%excludedTargets.name", description = "%excludedTargets.description")
     String[] excludedTargets() default {};
+
+    @AttributeDefinition(name = "%defaultRequireImportProviders.name", description = "%defaultRequireImportProviders.description")
+    String[] defaultRequireImportProviders() default {
+        OrderedJsonReader.EXT_ORDERED_JSON,
+        JsonReader.EXT_JSON,
+        XmlReader.EXT_XML,
+        ZipReader.EXT_ZIP,
+        ZipReader.EXT_JAR
+    };
+
 }

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderUnavailableException.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderUnavailableException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader.internal;
+
+/**
+ * This exception is thrown when a required ContentReader is not yet
+ * available.
+ */
+class ContentReaderUnavailableException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public ContentReaderUnavailableException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderWhiteboard.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderWhiteboard.java
@@ -30,9 +30,18 @@ import org.osgi.service.component.annotations.ReferencePolicy;
     })
 public class ContentReaderWhiteboard {
 
+    private ContentReaderWhiteboardListener listener;
+
     private Map<String, ContentReader> readersByExtension = new LinkedHashMap<>();
 
     private Map<String, ContentReader> readersByType = new LinkedHashMap<>();
+
+    public void setListener(ContentReaderWhiteboardListener listener) {
+        this.listener = listener;
+    }
+    public void removeListener() {
+        setListener(null);
+    }
 
     public Map<String, ContentReader> getReadersByExtension() {
         return readersByExtension;
@@ -60,6 +69,12 @@ public class ContentReaderWhiteboard {
                     readersByType.put(type, operation);
                 }
             }
+        }
+
+        // notify the listener that we have a new content reader
+        ContentReaderWhiteboardListener l = this.listener;
+        if (l != null) {
+            l.handleContentReaderAdded(operation);
         }
     }
 

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderWhiteboardListener.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/ContentReaderWhiteboardListener.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the
+ * NOTICE file distributed with this work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.sling.jcr.contentloader.internal;
+
+import org.apache.sling.jcr.contentloader.ContentReader;
+
+/**
+ * Callback interface to allow the BundleContentLoaderListener to do work
+ * when a new ContentReader component arrives
+ */
+public interface ContentReaderWhiteboardListener {
+
+    void handleContentReaderAdded(final ContentReader operation);
+
+}

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReader.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReader.java
@@ -108,8 +108,9 @@ import org.osgi.service.component.annotations.Component;
  * </pre>
  */
 @Component(service = ContentReader.class, property = { Constants.SERVICE_VENDOR + "=The Apache Software Foundation",
-        ContentReader.PROPERTY_EXTENSIONS + "=json", ContentReader.PROPERTY_TYPES + "=application/json" })
+        ContentReader.PROPERTY_EXTENSIONS + "=" + JsonReader.EXT_JSON, ContentReader.PROPERTY_TYPES + "=application/json" })
 public class JsonReader implements ContentReader {
+    public static final String EXT_JSON = "json";
 
     private static final Pattern jsonDate = Pattern.compile(
             "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3}[-+]{1}[0-9]{2}[:]{0,1}[0-9]{2}$");

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReader.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReader.java
@@ -43,10 +43,11 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ContentReader.class,
 property = {
     Constants.SERVICE_VENDOR + "=The Apache Software Foundation",
-    ContentReader.PROPERTY_EXTENSIONS + "=ordered-json",
+    ContentReader.PROPERTY_EXTENSIONS + "=" + OrderedJsonReader.EXT_ORDERED_JSON,
     ContentReader.PROPERTY_TYPES + "=application/json"
 })
 public class OrderedJsonReader extends JsonReader {
+    public static final String EXT_ORDERED_JSON = "ordered-json";
 
     private static final String PN_ORDEREDCHILDREN = "SLING:ordered";
     private static final String PN_ORDEREDCHILDNAME = "SLING:name";

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/XmlReader.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/XmlReader.java
@@ -99,9 +99,10 @@ import org.xmlpull.v1.XmlPullParserException;
  * <code>&lt;nt:file&gt;</code> element.
  */
 @Component(service = ContentReader.class, property = { Constants.SERVICE_VENDOR + "=The Apache Software Foundation",
-        ContentReader.PROPERTY_EXTENSIONS + "=xml", ContentReader.PROPERTY_TYPES + "=application/xml",
+        ContentReader.PROPERTY_EXTENSIONS + "=" + XmlReader.EXT_XML, ContentReader.PROPERTY_TYPES + "=application/xml",
         ContentReader.PROPERTY_TYPES + "=text/xml" })
 public class XmlReader implements ContentReader {
+    public static final String EXT_XML = "xml";
 
     /*
      * <node> <primaryNodeType>type</primaryNodeType> <mixinNodeTypes>

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReader.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReader.java
@@ -40,12 +40,14 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ContentReader.class,
     property = {
         Constants.SERVICE_VENDOR + "=The Apache Software Foundation",
-        ContentReader.PROPERTY_EXTENSIONS + "=zip",
-        ContentReader.PROPERTY_EXTENSIONS + "=jar",
+        ContentReader.PROPERTY_EXTENSIONS + "=" + ZipReader.EXT_ZIP,
+        ContentReader.PROPERTY_EXTENSIONS + "=" + ZipReader.EXT_JAR,
         ContentReader.PROPERTY_TYPES + "=application/zip",
         ContentReader.PROPERTY_TYPES + "=application/java-archive"
 })
 public class ZipReader implements ContentReader {
+    public static final String EXT_ZIP = "zip";
+    public static final String EXT_JAR = "jar";
 
     private static final String NT_FOLDER = "nt:folder";
 

--- a/src/main/resources/OSGI-INF/l10n/bundle.properties
+++ b/src/main/resources/OSGI-INF/l10n/bundle.properties
@@ -31,3 +31,7 @@ will be evaluated first
 excludedTargets.name=Excluded Targets
 excludedTargets.description=An array of regular expressions for the Path Entry targets to exclude when installing content \
 will be evaluated after include
+
+defaultRequireImportProviders.name=Default Require Import Providers
+defaultRequireImportProviders.description=An array of file extensions that should be the default set to consider when no \
+requireImportProviders directive is supplied for a Path Entry

--- a/src/test/java/org/apache/sling/jcr/contentloader/ImportOptionsFactory.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/ImportOptionsFactory.java
@@ -16,6 +16,10 @@
  */
 package org.apache.sling.jcr.contentloader;
 
+import java.util.Collection;
+
+import org.jetbrains.annotations.NotNull;
+
 public final class ImportOptionsFactory {
     
     public static final int NO_OPTIONS = 0;
@@ -33,8 +37,9 @@ public final class ImportOptionsFactory {
     public static final int IGNORE_IMPORT_PROVIDER = 0x1 << 5;
     
     public static final int CHECK_IN = 0x1 << 6;
-    
-    
+
+    public static final int REQUIRE_IMPORT_PROVIDER = 0x1 << 7;
+
     public static ImportOptions createImportOptions(int options){
         return new ImportOptions() {
             @Override
@@ -60,6 +65,11 @@ public final class ImportOptionsFactory {
             @Override
             public boolean isIgnoredImportProvider(String extension) {
                 return (options & IGNORE_IMPORT_PROVIDER) > NO_OPTIONS;
+            }
+
+            @Override
+            public boolean isImportProviderRequired(@NotNull String name, @NotNull Collection<String> defaultImportProviderRequired) {
+                return (options & REQUIRE_IMPORT_PROVIDER) > NO_OPTIONS;
             }
 
             @Override

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
@@ -218,6 +218,13 @@ public class BundleContentLoaderTest {
                         return new String[] { "^/libs.*$" };
                     }
 
+                    @Override
+                    public String[] defaultRequireImportProviders() {
+                        return new String[] {
+                                XmlReader.EXT_XML
+                        };
+                    }
+
                 });
 
         Bundle mockBundle = newBundleWithInitialContent(context, 
@@ -249,6 +256,13 @@ public class BundleContentLoaderTest {
                         return null;
                     }
 
+                    @Override
+                    public String[] defaultRequireImportProviders() {
+                        return new String[] {
+                                XmlReader.EXT_XML
+                        };
+                    }
+
                 });
 
         Bundle mockBundle = newBundleWithInitialContent(context,
@@ -278,6 +292,13 @@ public class BundleContentLoaderTest {
                     @Override
                     public String[] excludedTargets() {
                         return new String[] { "^/app.*$" };
+                    }
+
+                    @Override
+                    public String[] defaultRequireImportProviders() {
+                        return new String[] {
+                                XmlReader.EXT_XML
+                        };
                     }
 
                 });

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/SLING11189Test.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/SLING11189Test.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader.internal;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.jcr.Session;
+
+import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+/**
+ * Testing content loader waiting for required content reader
+ */
+public class SLING11189Test {
+
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    private BundleContentLoaderListener bundleHelper;
+
+    protected void prepareContentLoader(Map<String, Object> bundleContentLoaderConfig) throws Exception {
+        // NOTE: initially no content readers are registered
+
+        // whiteboard which holds readers
+        context.registerInjectActivateService(new ContentReaderWhiteboard());
+
+        // register the content loader service
+        bundleHelper = context.registerInjectActivateService(new BundleContentLoaderListener(), bundleContentLoaderConfig);
+
+    }
+
+    @Test
+    public void loadContentWithoutDefaultExpectedContentReaderRegistered() throws Exception {
+        loadContentWithoutDirectiveAndWithDefault();
+
+        assertThat("Included resource should not have been imported", context.resourceResolver().getResource("/libs/app"), nullValue());
+    }
+
+    @Test
+    public void loadContentWithoutDirectiveExpectedContentReaderRegistered() throws Exception {
+        loadContentWithDirectiveAndWithoutDefault();
+
+        assertThat("Included resource should not have been imported", context.resourceResolver().getResource("/libs/app"), nullValue());
+    }
+
+    @Test
+    public void loadContentWithDefaultExpectedContentReaderRegisteredBeforeBundleLoaded() throws Exception {
+        // register the content reader that we require before registering the bundle
+        context.registerInjectActivateService(new XmlReader());
+
+        loadContentWithoutDirectiveAndWithDefault();
+
+        assertThat("Included resource should have been imported", context.resourceResolver().getResource("/libs/app"), notNullValue());
+    }
+
+    @Test
+    public void loadContentWithDirectiveExpectedContentReaderRegisteredBeforeBundleLoaded() throws Exception {
+        // register the content reader that we require before registering the bundle
+        context.registerInjectActivateService(new XmlReader());
+
+        loadContentWithDirectiveAndWithoutDefault();
+
+        assertThat("Included resource should have been imported", context.resourceResolver().getResource("/libs/app"), notNullValue());
+    }
+
+    @Test
+    public void loadContentWithDefaultExpectedContentReaderRegisteredAfterBundleLoaded() throws Exception {
+        loadContentWithoutDirectiveAndWithDefault();
+
+        assertThat("Included resource should not have been imported", context.resourceResolver().getResource("/libs/app"), nullValue());
+
+        // register the content reader that we require after registering the bundle
+        //   to trigger the retry
+        context.registerInjectActivateService(new XmlReader());
+
+        assertThat("Included resource should have been imported", context.resourceResolver().getResource("/libs/app"), notNullValue());
+    }
+
+    @Test
+    public void loadContentWithDirectiveExpectedContentReaderRegisteredAfterBundleLoaded() throws Exception {
+        loadContentWithDirectiveAndWithoutDefault();
+
+        assertThat("Included resource should not have been imported", context.resourceResolver().getResource("/libs/app"), nullValue());
+
+        // register the content reader that we require after registering the bundle
+        //   to trigger the retry
+        context.registerInjectActivateService(new XmlReader());
+
+        assertThat("Included resource should have been imported", context.resourceResolver().getResource("/libs/app"), notNullValue());
+    }
+
+    protected void loadContentWithoutDirectiveAndWithDefault() throws Exception {
+        // prepare the content loader with the default configuration
+        prepareContentLoader(null);
+
+        // dig the BundleContentLoader out of the component field so we get the
+        //  same instance so the state for the retry logic is there
+        Field privateBundleContentLoaderField = BundleContentLoaderListener.class.getDeclaredField("bundleContentLoader");
+        privateBundleContentLoaderField.setAccessible(true);
+        BundleContentLoader contentLoader = (BundleContentLoader)privateBundleContentLoaderField.get(bundleHelper);
+
+        // no requireImportProviders directive, so it should fallback to the
+        //  the defaultRequireImportProviders configuration to check if the 
+        //  required content reader is available
+        String initialContentHeader = "SLING-INF/libs;path:=/libs";
+        Bundle mockBundle = BundleContentLoaderTest.newBundleWithInitialContent(context, initialContentHeader);
+
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+    }
+
+    protected void loadContentWithDirectiveAndWithoutDefault() throws Exception {
+        // prepare the content loader with customized configuration
+        //  to clear out the defaultRequireImportProviders values 
+        prepareContentLoader(Collections.singletonMap("defaultRequireImportProviders", new String[0]));
+
+        // dig the BundleContentLoader out of the component field so we get the
+        //  same instance so the state for the retry logic is there
+        Field privateBundleContentLoaderField = BundleContentLoaderListener.class.getDeclaredField("bundleContentLoader");
+        privateBundleContentLoaderField.setAccessible(true);
+        BundleContentLoader contentLoader = (BundleContentLoader)privateBundleContentLoaderField.get(bundleHelper);
+
+        // requireImportProviders directive, so it should check if the specified 
+        //  required content reader is available
+        String initialContentHeader = "SLING-INF/libs;path:=/libs;requireImportProviders:=xml";
+        Bundle mockBundle = BundleContentLoaderTest.newBundleWithInitialContent(context, initialContentHeader);
+
+        contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
+    }
+
+}


### PR DESCRIPTION
A declared requireImportProvider directive or configured defaultRequireImportProviders list so the author can ensure that the
files are processed as intended

This is an attempt an implementation of what I proposed at https://github.com/apache/sling-org-apache-sling-jcr-contentloader/pull/12#issuecomment-1062982927
