### PR TITLE
SLING-11194 Content Loader: Add log message if Sling-Initial-Content is not processed due to stale lock node at /var/sling/bundle-content

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderListener.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderListener.java
@@ -350,6 +350,7 @@ public class BundleContentLoaderListener implements SynchronousBundleListener, B
         }
         final Node bcNode = parentNode.getNode(nodeName);
         if (bcNode.isLocked()) {
+            this.log.debug("Node {}/{} is currently locked, unable to get BundleContentInfo.", BUNDLE_CONTENT_NODE, nodeName);
             return null;
         }
         try {
@@ -359,6 +360,7 @@ public class BundleContentLoaderListener implements SynchronousBundleListener, B
                     Long.MAX_VALUE, // timeoutHint
                     null); // ownerInfo
         } catch (LockException le) {
+            this.log.debug("Unable to lock node {}/{}, unable to get BundleContentInfo.", BUNDLE_CONTENT_NODE, nodeName, le);
             return null;
         }
         final Map<String, Object> info = new HashMap<>();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-11194