### PR TITLE
SLING-11713 Change ACL json input structure

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/ContentCreator.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/ContentCreator.java
@@ -19,6 +19,7 @@
 package org.apache.sling.jcr.contentloader;
 
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -203,6 +204,28 @@ public interface ContentCreator {
     	throw new UnsupportedOperationException();
 	}
     
+    /**
+     * Creates an Access Control Entry for the current node for the specified
+     * principal and privileges.
+     *
+     * @param principal         the user or group id for the ACE
+     * @param privileges        the set of privileges to allow or deny for the principal
+     * @param order             specifies the position of the ACE in the containing ACL. (may be null)
+     *                          Value should be one of these:
+     *                          <table>
+     *                          <caption>Values</caption>
+     *                          <tr><td>first</td><td>Place the target ACE as the first amongst its siblings</td></tr>
+     *                          <tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
+     *                          <tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
+     *                          <tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
+     *                          <tr><td>numeric</td><td>Place the target ACE at the specified index</td></tr>
+     *                          </table>
+     * @throws RepositoryException If anything goes wrong.
+     */
+    default void createAce(String principal, Collection<LocalPrivilege> privileges, String order) throws RepositoryException {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * Gets the current parent Node
      * @return the current parent node or null

--- a/src/main/java/org/apache/sling/jcr/contentloader/LocalPrivilege.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/LocalPrivilege.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
+
+public class LocalPrivilege {
+    private String privilegeName;
+    private boolean allow;
+    private boolean deny;
+    private Set<LocalRestriction> allowRestrictions = Collections.emptySet();
+    private Set<LocalRestriction> denyRestrictions = Collections.emptySet();
+    private Privilege privilege;
+
+    public LocalPrivilege(String privilege) {
+        this.privilegeName = privilege;
+    }
+
+    public void checkPrivilege(AccessControlManager acm) throws RepositoryException {
+        this.privilege = acm.privilegeFromName(this.privilegeName);
+    }
+
+    public Privilege getPrivilege() {
+        return this.privilege;
+    }
+
+    public String getName() {
+        return privilegeName;
+    }
+
+    public boolean isAllow() {
+        return allow;
+    }
+
+    public boolean isDeny() {
+        return deny;
+    }
+
+    public void setAllow(boolean allow) {
+        this.allow = allow;
+    }
+
+    public void setDeny(boolean deny) {
+        this.deny = deny;
+    }
+
+    public Set<LocalRestriction> getAllowRestrictions() {
+        return allowRestrictions;
+    }
+
+    public void setAllowRestrictions(Set<LocalRestriction> allowRestrictions) {
+        this.allowRestrictions = allowRestrictions;
+    }
+
+    public Set<LocalRestriction> getDenyRestrictions() {
+        return denyRestrictions;
+    }
+
+    public void setDenyRestrictions(Set<LocalRestriction> denyRestrictions) {
+        this.denyRestrictions = denyRestrictions;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LocalPrivilege [privilege=");
+        builder.append(privilegeName);
+        builder.append(", allow=");
+        builder.append(allow);
+        builder.append(", deny=");
+        builder.append(deny);
+        builder.append(", allowRestrictions=");
+        builder.append(allowRestrictions);
+        builder.append(", denyRestrictions=");
+        builder.append(denyRestrictions);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (allow ? 1231 : 1237);
+        result = prime * result + ((allowRestrictions == null) ? 0 : allowRestrictions.hashCode());
+        result = prime * result + (deny ? 1231 : 1237);
+        result = prime * result + ((denyRestrictions == null) ? 0 : denyRestrictions.hashCode());
+        result = prime * result + ((privilegeName == null) ? 0 : privilegeName.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        LocalPrivilege other = (LocalPrivilege) obj;
+        if (allow != other.allow)
+            return false;
+        if (allowRestrictions == null) {
+            if (other.allowRestrictions != null)
+                return false;
+        } else if (!allowRestrictions.equals(other.allowRestrictions))
+            return false;
+        if (deny != other.deny)
+            return false;
+        if (denyRestrictions == null) {
+            if (other.denyRestrictions != null)
+                return false;
+        } else if (!denyRestrictions.equals(other.denyRestrictions))
+            return false;
+        if (privilegeName == null) {
+            if (other.privilegeName != null)
+                return false;
+        } else if (!privilegeName.equals(other.privilegeName))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/contentloader/LocalRestriction.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/LocalRestriction.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader;
+
+import java.util.Arrays;
+
+import javax.jcr.Value;
+
+import org.jetbrains.annotations.NotNull;
+
+public class LocalRestriction {
+    private String restriction;
+    private boolean multival;
+    private Value[] values;
+
+    public LocalRestriction(@NotNull String restriction, Value[] values) {
+        this.restriction = restriction;
+        this.multival = true;
+        this.values = values;
+    }
+
+    public LocalRestriction(@NotNull String restriction, Value value) {
+        super();
+        this.restriction = restriction;
+        this.multival = false;
+        this.values = new Value[] {value};
+    }
+
+    public String getName() {
+        return restriction;
+    }
+
+    public boolean isMultiValue() {
+        return multival;
+    }
+
+    public Value getValue() {
+        Value v = null;
+        if (values != null && values.length > 0) {
+            v = values[0];
+        }
+        return v;
+    }
+
+    public Value[] getValues() {
+        return values;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LocalRestriction [restriction=");
+        builder.append(restriction);
+        builder.append(", multival=");
+        builder.append(multival);
+        builder.append(", values=");
+        builder.append(Arrays.toString(values));
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (multival ? 1231 : 1237);
+        result = prime * result + ((restriction == null) ? 0 : restriction.hashCode());
+        result = prime * result + Arrays.hashCode(values);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        LocalRestriction other = (LocalRestriction) obj;
+        if (multival != other.multival)
+            return false;
+        if (restriction == null) {
+            if (other.restriction != null)
+                return false;
+        } else if (!restriction.equals(other.restriction))
+            return false;
+        if (!Arrays.equals(values, other.values))
+            return false;
+        return true;
+    }
+
+}

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
@@ -26,10 +26,12 @@ import java.security.Principal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,21 +52,35 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
 import javax.jcr.ValueFactory;
+import javax.jcr.security.AccessControlEntry;
+import javax.jcr.security.AccessControlException;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.AccessControlPolicy;
+import javax.jcr.security.AccessControlPolicyIterator;
+import javax.jcr.security.Privilege;
 import javax.jcr.version.VersionManager;
 
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.util.ISO8601;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.contentloader.ContentCreator;
 import org.apache.sling.jcr.contentloader.ContentImportListener;
 import org.apache.sling.jcr.contentloader.ContentReader;
 import org.apache.sling.jcr.contentloader.ImportOptions;
+import org.apache.sling.jcr.contentloader.LocalPrivilege;
+import org.apache.sling.jcr.contentloader.LocalRestriction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -884,6 +900,357 @@ public class DefaultContentCreator implements ContentCreator {
         if ((grantedPrivilegeNames != null) || (deniedPrivilegeNames != null)) {
             AccessControlUtil.replaceAccessControlEntry(session, resourcePath, principal, grantedPrivilegeNames, deniedPrivilegeNames, null, order, 
             		restrictions, mvRestrictions, removedRestrictionNames);
+        }
+    }
+
+    @Override
+    public void createAce(String principalId, Collection<LocalPrivilege> privileges, String order)
+            throws RepositoryException {
+        final Node parentNode = this.parentNodeStack.peek();
+        Session jcrSession = parentNode.getSession();
+
+        // validate that the principal name is valid
+        PrincipalManager principalManager = AccessControlUtil.getPrincipalManager(jcrSession);
+        Principal principal = principalManager.getPrincipal(principalId);
+        if (principal == null) {
+            // SLING-7268 - as pointed out in OAK-5496, we cannot successfully use
+            // PrincipalManager#getPrincipal in oak
+            // without the session that created the principal getting saved first (and a
+            // subsequent index update).
+            // Workaround by trying the UserManager#getAuthorizable API to locate the
+            // principal.
+            UserManager userManager = AccessControlUtil.getUserManager(jcrSession);
+            final Authorizable authorizable = userManager.getAuthorizable(principalId);
+            if (authorizable != null) {
+                principal = authorizable.getPrincipal();
+            }
+        }
+
+        if (principal == null) {
+            throw new RepositoryException("No principal found for id: " + principalId);
+        }
+
+        // validate that the privilege names are valid
+        AccessControlManager acm = AccessControlUtil.getAccessControlManager(jcrSession);
+        for (LocalPrivilege localPrivilege: privileges) {
+            localPrivilege.checkPrivilege(acm);
+        }
+
+        String resourcePath = parentNode.getPath();
+
+        // build a list of each of the LocalPrivileges that have the same restrictions
+        Map<Set<LocalRestriction>, List<LocalPrivilege>> allowRestrictionsToLocalPrivilegesMap = new HashMap<>();
+        Map<Set<LocalRestriction>, List<LocalPrivilege>> denyRestrictionsToLocalPrivilegesMap = new HashMap<>();
+        for (LocalPrivilege localPrivilege: privileges) {
+            if (localPrivilege.isAllow()) {
+                List<LocalPrivilege> list = allowRestrictionsToLocalPrivilegesMap.computeIfAbsent(localPrivilege.getAllowRestrictions(), key -> new ArrayList<>());
+                list.add(localPrivilege);
+            }
+            if (localPrivilege.isDeny()) {
+                List<LocalPrivilege> list = denyRestrictionsToLocalPrivilegesMap.computeIfAbsent(localPrivilege.getDenyRestrictions(), key -> new ArrayList<>());
+                list.add(localPrivilege);
+            }
+        }
+
+        try {
+            // Get or create the ACL for the node.
+            JackrabbitAccessControlList acl = getAcl(acm, resourcePath, principal);
+
+            // remove all the old aces for the principal
+            order = removeAces(resourcePath, order, principal, acl);
+
+            // now add all the new aces that we have collected
+            Map<Privilege, Integer> privilegeLongestDepthMap = buildPrivilegeLongestDepthMap(acm.privilegeFromName(PrivilegeConstants.JCR_ALL));
+            addAces(resourcePath, principal, denyRestrictionsToLocalPrivilegesMap, false, acl, privilegeLongestDepthMap);
+            addAces(resourcePath, principal, allowRestrictionsToLocalPrivilegesMap, true, acl, privilegeLongestDepthMap);
+
+            // reorder the aces
+            reorderAccessControlEntries(acl, principal, order);
+
+            // Store the actual changes.
+            acm.setPolicy(acl.getPath(), acl);
+        } catch (RepositoryException re) {
+            throw new RepositoryException("Failed to create ace.", re);
+        }
+    }
+
+    /**
+     * If the privilege is contained in multiple aggregate privileges, then
+     * calculate the instance with the greatest depth.
+     */
+    private static void toLongestDepth(int parentDepth, Privilege parentPrivilege, Map<Privilege, Integer> privilegeToLongestDepth) {
+        Privilege[] declaredAggregatePrivileges = parentPrivilege.getDeclaredAggregatePrivileges();
+        for (Privilege privilege : declaredAggregatePrivileges) {
+            Integer oldValue = privilegeToLongestDepth.get(privilege);
+            int candidateDepth = parentDepth + 1;
+            if (oldValue == null || oldValue.intValue() < candidateDepth) {
+                privilegeToLongestDepth.put(privilege, candidateDepth);
+
+                // continue drilling down to the leaf privileges
+                toLongestDepth(candidateDepth, privilege, privilegeToLongestDepth);
+            }
+        }
+    }
+
+    /**
+     * Calculate the longest path for each of the possible privileges
+     * 
+     * @param jcrSession the current users JCR session
+     * @return map where the key is the privilege and the value is the longest path
+     */
+    public static Map<Privilege, Integer> buildPrivilegeLongestDepthMap(Privilege jcrAll) {
+        Map<Privilege, Integer> privilegeToLongestPath = new HashMap<>();
+        privilegeToLongestPath.put(jcrAll, 1);
+        toLongestDepth(1, jcrAll, privilegeToLongestPath);
+        return privilegeToLongestPath;
+    }
+
+    /**
+     * Lookup the ACL for the given resource
+     * 
+     * @param acm the access control manager
+     * @param resourcePath the resource path
+     * @param principal the principal for principalbased ACL
+     * @return the found ACL object
+     */
+    protected JackrabbitAccessControlList getAcl(@NotNull AccessControlManager acm, String resourcePath, Principal principal)
+            throws RepositoryException {
+        AccessControlPolicy[] policies = acm.getPolicies(resourcePath);
+        JackrabbitAccessControlList acl = null;
+        for (AccessControlPolicy policy : policies) {
+            if (policy instanceof JackrabbitAccessControlList) {
+                acl = (JackrabbitAccessControlList) policy;
+                break;
+            }
+        }
+        if (acl == null) {
+            AccessControlPolicyIterator applicablePolicies = acm.getApplicablePolicies(resourcePath);
+            while (applicablePolicies.hasNext()) {
+                AccessControlPolicy policy = applicablePolicies.nextAccessControlPolicy();
+                if (policy instanceof JackrabbitAccessControlList) {
+                    acl = (JackrabbitAccessControlList) policy;
+                    break;
+                }
+            }
+        }
+        return acl;
+    }
+
+    /**
+     * Remove all of the ACEs for the specified principal from the ACL
+     * 
+     * @param order the requested order (may be null)
+     * @param principal the principal whose aces should be removed
+     * @param acl the access control list to update
+     * @return the original order if it was supplied, otherwise the order of the first ACE 
+     */
+    protected String removeAces(@NotNull String resourcePath, @Nullable String order, @NotNull Principal principal, @NotNull JackrabbitAccessControlList acl) // NOSONAR
+            throws RepositoryException {
+        AccessControlEntry[] existingAccessControlEntries = acl.getAccessControlEntries();
+
+        if (order == null || order.length() == 0) {
+            //order not specified, so keep track of the original ACE position.
+            Set<Principal> processedPrincipals = new HashSet<>();
+            for (int j = 0; j < existingAccessControlEntries.length; j++) {
+                AccessControlEntry ace = existingAccessControlEntries[j];
+                Principal principal2 = ace.getPrincipal();
+                if (principal2.equals(principal)) {
+                    order = String.valueOf(processedPrincipals.size());
+                    break;
+                } else {
+                    processedPrincipals.add(principal2);
+                }
+            }
+        }
+
+        for (int j = 0; j < existingAccessControlEntries.length; j++) {
+            AccessControlEntry ace = existingAccessControlEntries[j];
+            if (ace.getPrincipal().equals(principal)) {
+                acl.removeAccessControlEntry(ace);
+            }
+        }
+        return order;
+    }
+
+    /**
+     * Add ACEs for the specified principal to the ACL.  One ACE is added for each unique
+     * restriction set.
+     * 
+     * @param resourcePath the path of the resource
+     * @param principal the principal whose aces should be added
+     * @param restrictionsToLocalPrivilegesMap the map containing the restrictions mapped to the LocalPrivlege items with those resrictions
+     * @param isAllow true for 'allow' ACE, false for 'deny' ACE
+     * @param acl the access control list to update
+     */
+    protected void addAces(@NotNull String resourcePath, @NotNull Principal principal,
+            @NotNull Map<Set<LocalRestriction>, List<LocalPrivilege>> restrictionsToLocalPrivilegesMap,
+            boolean isAllow,
+            @NotNull JackrabbitAccessControlList acl,
+            Map<Privilege, Integer> privilegeLongestDepthMap) throws RepositoryException {
+
+        List<Entry<Set<LocalRestriction>, List<LocalPrivilege>>> sortedEntries = new ArrayList<>(restrictionsToLocalPrivilegesMap.entrySet());
+        // sort the entries by the most shallow depth of the contained privileges
+        Collections.sort(sortedEntries, (e1, e2) -> {
+                        int shallowestDepth1 = Integer.MAX_VALUE;
+                        for (LocalPrivilege lp : e1.getValue()) {
+                            Integer depth = privilegeLongestDepthMap.get(lp.getPrivilege());
+                            if (depth != null && depth.intValue() < shallowestDepth1) {
+                                shallowestDepth1 = depth.intValue();
+                            }
+                        }
+                        int shallowestDepth2 = Integer.MAX_VALUE;
+                        for (LocalPrivilege lp : e2.getValue()) {
+                            Integer depth = privilegeLongestDepthMap.get(lp.getPrivilege());
+                            if (depth != null && depth.intValue() < shallowestDepth2) {
+                                shallowestDepth2 = depth.intValue();
+                            }
+                        }
+                        return Integer.compare(shallowestDepth1, shallowestDepth2);
+                    });
+
+        for (Entry<Set<LocalRestriction>, List<LocalPrivilege>> entry: sortedEntries) {
+            Set<Privilege> privilegesSet = new HashSet<>();
+            Map<String, Value> restrictions = new HashMap<>(); 
+            Map<String, Value[]> mvRestrictions = new HashMap<>();
+
+            Set<LocalRestriction> localRestrictions = entry.getKey();
+            for (LocalRestriction localRestriction : localRestrictions) {
+                if (localRestriction.isMultiValue()) {
+                    mvRestrictions.put(localRestriction.getName(), localRestriction.getValues());
+                } else {
+                    restrictions.put(localRestriction.getName(), localRestriction.getValue());
+                }
+            }
+
+            for (LocalPrivilege localPrivilege : entry.getValue()) {
+                privilegesSet.add(localPrivilege.getPrivilege());
+            }
+
+            if (!privilegesSet.isEmpty()) {
+                acl.addEntry(principal, privilegesSet.toArray(new Privilege[privilegesSet.size()]), isAllow, restrictions, mvRestrictions);
+            }
+        }
+    }
+
+    /**
+     * Move the ACE(s) for the specified principal to the position specified by the 'order'
+     * parameter. This is a copy of the private AccessControlUtil.reorderAccessControlEntries method.
+     *
+     * @param acl the acl of the node containing the ACE to position
+     * @param principal the user or group of the ACE to position
+     * @param order where the access control entry should go in the list.
+     *         Value should be one of these:
+     *         <table>
+     *          <caption>Values</caption>
+     *          <tr><td>first</td><td>Place the target ACE as the first amongst its siblings</td></tr>
+     *          <tr><td>last</td><td>Place the target ACE as the last amongst its siblings</td></tr>
+     *          <tr><td>before xyz</td><td>Place the target ACE immediately before the sibling whose name is xyz</td></tr>
+     *          <tr><td>after xyz</td><td>Place the target ACE immediately after the sibling whose name is xyz</td></tr>
+     *          <tr><td>numeric</td><td>Place the target ACE at the specified index</td></tr>
+     *         </table>
+     * @throws RepositoryException
+     * @throws UnsupportedRepositoryOperationException
+     * @throws AccessControlException
+     */
+    private static void reorderAccessControlEntries(AccessControlList acl,
+            Principal principal, String order) throws RepositoryException {
+        if (order == null || order.length() == 0) {
+            return; //nothing to do
+        }
+        if (acl instanceof JackrabbitAccessControlList) {
+            JackrabbitAccessControlList jacl = (JackrabbitAccessControlList)acl;
+
+            AccessControlEntry[] accessControlEntries = jacl.getAccessControlEntries();
+            if (accessControlEntries.length <= 1) {
+                return; //only one ACE, so nothing to reorder.
+            }
+
+            AccessControlEntry beforeEntry = null;
+            if ("first".equals(order)) {
+                beforeEntry = accessControlEntries[0];
+            } else if ("last".equals(order)) {
+                // add to the end is the same as default
+            } else if (order.startsWith("before ")) {
+                String beforePrincipalName = order.substring(7);
+
+                //find the index of the ACE of the 'before' principal
+                for (int i=0; i < accessControlEntries.length; i++) {
+                    if (beforePrincipalName.equals(accessControlEntries[i].getPrincipal().getName())) {
+                        //found it!
+                        beforeEntry = accessControlEntries[i];
+                        break;
+                    }
+                }
+
+                if (beforeEntry == null) {
+                    //didn't find an ACE that matched the 'before' principal
+                    throw new IllegalArgumentException("No ACE was found for the specified principal: " + beforePrincipalName);
+                }
+            } else if (order.startsWith("after ")) {
+                String afterPrincipalName = order.substring(6);
+
+                //find the index of the ACE of the 'after' principal
+                for (int i = accessControlEntries.length - 1; i >= 0; i--) {
+                    if (afterPrincipalName.equals(accessControlEntries[i].getPrincipal().getName())) {
+                        //found it!
+
+                        // the 'before' ACE is the next one after the 'after' ACE
+                        if (i >= accessControlEntries.length - 1) {
+                            //the after is the last one in the list
+                            beforeEntry = null;
+                        } else {
+                            beforeEntry = accessControlEntries[i + 1];
+                        }
+                        break;
+                    }
+                }
+
+                if (beforeEntry == null) {
+                    //didn't find an ACE that matched the 'after' principal
+                    throw new IllegalArgumentException("No ACE was found for the specified principal: " + afterPrincipalName);
+                }
+            } else {
+                int index = -1;
+                try {
+                    index = Integer.parseInt(order);
+                } catch (NumberFormatException nfe) {
+                    //not a number.
+                    throw new IllegalArgumentException("Illegal value for the order parameter: " + order);
+                }
+                if (index > accessControlEntries.length) {
+                    //invalid index
+                    throw new IndexOutOfBoundsException("Index value is too large: " + index);
+                }
+
+                //the index value is the index of the principal.  A principal may have more
+                // than one ACEs (deny + grant), so we need to compensate.
+                Map<Principal, Integer> principalToIndex = new HashMap<>();
+                for (int i = 0; i < accessControlEntries.length; i++) {
+                    Principal principal2 = accessControlEntries[i].getPrincipal();
+                    Integer idx = i;
+                    principalToIndex.computeIfAbsent(principal2, key -> idx);
+                }
+                Integer[] sortedIndexes = principalToIndex.values().stream()
+                        .sorted()
+                        .toArray(size -> new Integer[size]);
+                if (index >= 0 && index < sortedIndexes.length - 1) {
+                    int idx = sortedIndexes[index];
+                    beforeEntry = accessControlEntries[idx];
+                }
+            }
+
+            if (beforeEntry != null) {
+                //now loop through the entries to move the affected ACEs to the specified
+                // position.
+                for (AccessControlEntry ace : accessControlEntries) {
+                    if (principal.equals(ace.getPrincipal())) {
+                        //this ACE is for the specified principal.
+                        jacl.orderBefore(ace, beforeEntry);
+                    }
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("The acl must be an instance of JackrabbitAccessControlList");
         }
     }
 

--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReader.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReader.java
@@ -25,10 +25,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -47,14 +51,18 @@ import javax.json.JsonString;
 import javax.json.JsonValue;
 import javax.json.JsonValue.ValueType;
 
+import org.apache.jackrabbit.oak.spi.security.authorization.restriction.CompositeRestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.sling.jcr.contentloader.ContentCreator;
 import org.apache.sling.jcr.contentloader.ContentReader;
+import org.apache.sling.jcr.contentloader.LocalPrivilege;
+import org.apache.sling.jcr.contentloader.LocalRestriction;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
 
@@ -465,115 +473,85 @@ public class JsonReader implements ContentReader {
      */
     private void createAce(JsonObject ace, ContentCreator contentCreator) throws RepositoryException {
         String principalID = ace.getString("principal");
-
-        String[] grantedPrivileges = null;
-        JsonArray granted = (JsonArray) ace.get("granted");
-        if (granted != null) {
-            grantedPrivileges = new String[granted.size()];
-            for (int a = 0; a < grantedPrivileges.length; a++) {
-                grantedPrivileges[a] = granted.getString(a);
-            }
-        }
-
-        String[] deniedPrivileges = null;
-        JsonArray denied = (JsonArray) ace.get("denied");
-        if (denied != null) {
-            deniedPrivileges = new String[denied.size()];
-            for (int a = 0; a < deniedPrivileges.length; a++) {
-                deniedPrivileges[a] = denied.getString(a);
-            }
-        }
-
         String order = ace.getString("order", null);
 
-        Map<String, Value> restrictionsMap = null;
-        Map<String, Value[]> mvRestrictionsMap = null;
-        Set<String> removedRestrictionNames = null;
-        JsonObject restrictions = (JsonObject) ace.get("restrictions");
-        if (restrictions != null) {
-            // lazy initialized map for quick lookup when processing restrictions
-            Map<String, RestrictionDefinition> supportedRestrictionsMap = new HashMap<>();
+        // first start with an empty map
+        Map<String, LocalPrivilege> privilegeToLocalPrivilegesMap = new LinkedHashMap<>();
 
-            Node parentNode = contentCreator.getParent();
+        Node parentNode = contentCreator.getParent();
+        ValueFactory vf = parentNode.getSession().getValueFactory();
 
-            RestrictionProvider restrictionProvider = null;
-            Bundle bundle = FrameworkUtil.getBundle(getClass());
-            BundleContext bundleContext = bundle.getBundleContext();
-            ServiceReference<RestrictionProvider> serviceReference = null;
-            try {
-                serviceReference = bundleContext.getServiceReference(RestrictionProvider.class);
-                restrictionProvider = bundleContext.getService(serviceReference);
+        // Calculate a map of restriction names to the restriction definition.
+        // Use for fast lookup during the calls below.
+        Map<String, RestrictionDefinition> srMap = toSrMap(parentNode);
 
-                if (restrictionProvider == null) {
-                    throw new JsonException(
-                            "No restriction provider is available so unable to process restriction values");
-                }
+        // for backward compatibility, process the older syntax
+        JsonArray granted = (JsonArray) ace.get("granted");
+        JsonArray denied = (JsonArray) ace.get("denied");
+        if (granted != null || denied != null) {
+            JsonValue restrictions = ace.get("restrictions");
+            Set<LocalRestriction> restrictionsSet = Collections.emptySet();
+            if (restrictions instanceof JsonObject) {
+                restrictionsSet = toLocalRestrictions((JsonObject)restrictions, srMap, vf);
+            }
 
-                // populate the map
-                Set<RestrictionDefinition> supportedRestrictions = restrictionProvider
-                        .getSupportedRestrictions(parentNode.getPath());
-                for (RestrictionDefinition restrictionDefinition : supportedRestrictions) {
-                    supportedRestrictionsMap.put(restrictionDefinition.getName(), restrictionDefinition);
-                }
-            } finally {
-                if (serviceReference != null) {
-                    bundleContext.ungetService(serviceReference);
+            if (granted != null) {
+                for (int a = 0; a < granted.size(); a++) {
+                    String privilegeName = granted.getString(a);
+                    LocalPrivilege lp = privilegeToLocalPrivilegesMap.computeIfAbsent(privilegeName, LocalPrivilege::new);
+                    lp.setAllow(true);
+                    lp.setAllowRestrictions(restrictionsSet);
                 }
             }
 
-            restrictionsMap = new HashMap<>();
-            mvRestrictionsMap = new HashMap<>();
-            removedRestrictionNames = new HashSet<>();
+            if (denied != null) {
+                for (int a = 0; a < denied.size(); a++) {
+                    String privilegeName = denied.getString(a);
+                    LocalPrivilege lp = privilegeToLocalPrivilegesMap.computeIfAbsent(privilegeName, LocalPrivilege::new);
+                    lp.setDeny(true);
+                    lp.setDenyRestrictions(restrictionsSet);
+                }
+            }
+        }
 
-            ValueFactory factory = parentNode.getSession().getValueFactory();
-
-            Set<String> keySet = restrictions.keySet();
-            for (String rname : keySet) {
-                if (rname.endsWith("@Delete")) {
-                    // add the key to the 'remove' set. the value doesn't matter and is ignored.
-                    String rname2 = rname.substring(9, rname.length() - 7);
-                    removedRestrictionNames.add(rname2);
-                } else {
-                    RestrictionDefinition rd = supportedRestrictionsMap.get(rname);
-                    if (rd == null) {
-                        // illegal restriction name?
-                        throw new JsonException("Invalid or not supported restriction name was supplied: " + rname);
+        // now process the newer syntax
+        JsonValue privileges = ace.get("privileges");
+        if (privileges instanceof JsonObject) {
+            JsonObject privilegesObj = (JsonObject)privileges;
+            for (Entry<String, JsonValue> entry : privilegesObj.entrySet()) {
+                String privilegeName = entry.getKey();
+                JsonValue privilegeValue = entry.getValue();
+                if (privilegeValue instanceof JsonObject) {
+                    JsonObject privilegeValueObj = (JsonObject)privilegeValue;
+                    JsonValue allow = privilegeValueObj.get("allow");
+                    boolean isAllow = false;
+                    Set<LocalRestriction> allowRestrictions = Collections.emptySet(); 
+                    if (allow instanceof JsonObject) {
+                        isAllow = true;
+                        allowRestrictions = toLocalRestrictions((JsonObject)allow, srMap, vf);
+                    } else if (JsonValue.TRUE.equals(allow)) {
+                        isAllow = true;
                     }
 
-                    boolean multival = rd.getRequiredType().isArray();
-                    int restrictionType = rd.getRequiredType().tag();
+                    JsonValue deny = privilegeValueObj.get("deny");
+                    boolean isDeny = false;
+                    Set<LocalRestriction> denyRestrictions = Collections.emptySet(); 
+                    if (deny instanceof JsonObject) {
+                        isDeny = true;
+                        denyRestrictions = toLocalRestrictions((JsonObject)deny, srMap, vf);
+                    } else if (JsonValue.TRUE.equals(deny)) {
+                        isDeny = true;
+                    }
 
-                    // read the requested restriction value and apply it
-                    JsonValue jsonValue = restrictions.get(rname);
-
-                    if (multival) {
-                        if (jsonValue.getValueType() == ValueType.ARRAY) {
-                            JsonArray jsonArray = (JsonArray) jsonValue;
-                            int size = jsonArray.size();
-                            Value[] values = new Value[size];
-                            for (int i = 0; i < size; i++) {
-                                values[i] = toValue(factory, jsonArray.get(i), restrictionType);
-                            }
-                            mvRestrictionsMap.put(rname, values);
-                        } else {
-                            Value v = toValue(factory, jsonValue, restrictionType);
-                            mvRestrictionsMap.put(rname, new Value[] { v });
+                    if (isAllow || isDeny) {
+                        LocalPrivilege lp = privilegeToLocalPrivilegesMap.computeIfAbsent(privilegeName, LocalPrivilege::new);
+                        if (isAllow) {
+                            lp.setAllow(true);
+                            lp.setAllowRestrictions(allowRestrictions);
                         }
-                    } else {
-                        if (jsonValue.getValueType() == ValueType.ARRAY) {
-                            JsonArray jsonArray = (JsonArray) jsonValue;
-                            int size = jsonArray.size();
-                            if (size == 1) {
-                                Value v = toValue(factory, jsonArray.get(0), restrictionType);
-                                restrictionsMap.put(rname, v);
-                            } else if (size > 1) {
-                                throw new JsonException(
-                                        "Unexpected multi value array data found for single-value restriction value for name: "
-                                                + rname);
-                            }
-                        } else {
-                            Value v = toValue(factory, jsonValue, restrictionType);
-                            restrictionsMap.put(rname, v);
+                        if (isDeny) {
+                            lp.setDeny(true);
+                            lp.setDenyRestrictions(denyRestrictions);
                         }
                     }
                 }
@@ -581,12 +559,113 @@ public class JsonReader implements ContentReader {
         }
 
         // do the work.
-        if (restrictionsMap == null && mvRestrictionsMap == null && removedRestrictionNames == null) {
-            contentCreator.createAce(principalID, grantedPrivileges, deniedPrivileges, order);
-        } else {
-            contentCreator.createAce(principalID, grantedPrivileges, deniedPrivileges, order, restrictionsMap,
-                    mvRestrictionsMap, removedRestrictionNames == null ? null : removedRestrictionNames);
+        contentCreator.createAce(principalID, new ArrayList<>(privilegeToLocalPrivilegesMap.values()), order);
+    }
+
+    /**
+     * Calculate a map of restriction names to the restriction definition
+     * 
+     * @param parentNode the node the restrictions are for
+     */
+    protected Map<String, RestrictionDefinition> toSrMap(Node parentNode)
+            throws RepositoryException {
+        // lazy initialized map for quick lookup when processing restrictions
+        Map<String, RestrictionDefinition> supportedRestrictionsMap = new HashMap<>();
+
+        RestrictionProvider compositeRestrictionProvider = null;
+        Set<RestrictionProvider> restrictionProviders = new HashSet<>();
+
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        if (bundle != null) {
+            BundleContext bundleContext = bundle.getBundleContext();
+            Collection<ServiceReference<RestrictionProvider>> serviceReferences = null;
+            try {
+                serviceReferences = bundleContext.getServiceReferences(RestrictionProvider.class, null);
+                for (ServiceReference<RestrictionProvider> serviceReference : serviceReferences) {
+                    RestrictionProvider service = bundleContext.getService(serviceReference);
+                    restrictionProviders.add(service);
+                }
+                compositeRestrictionProvider = CompositeRestrictionProvider.newInstance(restrictionProviders);
+
+                // populate the map
+                Set<RestrictionDefinition> supportedRestrictions = compositeRestrictionProvider
+                        .getSupportedRestrictions(parentNode.getPath());
+                for (RestrictionDefinition restrictionDefinition : supportedRestrictions) {
+                    supportedRestrictionsMap.put(restrictionDefinition.getName(), restrictionDefinition);
+                }
+            } catch (InvalidSyntaxException e) {
+                throw new RepositoryException(e);
+            } finally {
+                if (serviceReferences != null) {
+                    for (ServiceReference<RestrictionProvider> serviceReference : serviceReferences) {
+                        bundleContext.ungetService(serviceReference);
+                    }
+                }
+            }
         }
+        return supportedRestrictionsMap;
+    }
+
+    /**
+     * Construct a LocalRestriction using data from the json object
+     * 
+     * @param allowOrDenyObj the json object
+     * @param srMap map of restriction names to the restriction definition
+     * @param vf the ValueFactory
+     */
+    protected Set<LocalRestriction> toLocalRestrictions(JsonObject allowOrDenyObj,
+            Map<String, RestrictionDefinition> srMap,
+            ValueFactory vf) throws RepositoryException {
+        Set<LocalRestriction> restrictions = new HashSet<>();
+        for (Entry<String, JsonValue> restrictionEntry : allowOrDenyObj.entrySet()) {
+            String restrictionName = restrictionEntry.getKey();
+            RestrictionDefinition rd = srMap.get(restrictionName);
+            if (rd == null) {
+                // illegal restriction name?
+                throw new JsonException("Invalid or not supported restriction name was supplied: " + restrictionName);
+            }
+
+            boolean multival = rd.getRequiredType().isArray();
+            int restrictionType = rd.getRequiredType().tag();
+
+            LocalRestriction lr = null;
+            JsonValue jsonValue = restrictionEntry.getValue();
+
+            if (multival) {
+                if (jsonValue.getValueType() == ValueType.ARRAY) {
+                    JsonArray jsonArray = (JsonArray) jsonValue;
+                    int size = jsonArray.size();
+                    Value[] values = new Value[size];
+                    for (int i = 0; i < size; i++) {
+                        values[i] = toValue(vf, jsonArray.get(i), restrictionType);
+                    }
+                    lr = new LocalRestriction(restrictionName, values);
+                } else {
+                    Value v = toValue(vf, jsonValue, restrictionType);
+                    lr = new LocalRestriction(restrictionName, new Value[] { v });
+                }
+            } else {
+                if (jsonValue.getValueType() == ValueType.ARRAY) {
+                    JsonArray jsonArray = (JsonArray) jsonValue;
+                    int size = jsonArray.size();
+                    if (size == 1) {
+                        Value v = toValue(vf, jsonArray.get(0), restrictionType);
+                        lr = new LocalRestriction(restrictionName, v);
+                    } else if (size > 1) {
+                        throw new JsonException(
+                                "Unexpected multi value array data found for single-value restriction value for name: "
+                                        + restrictionName);
+                    }
+                } else {
+                    Value v = toValue(vf, jsonValue, restrictionType);
+                    lr = new LocalRestriction(restrictionName, v);
+                }
+            }
+            if (lr != null) {
+                restrictions.add(lr);
+            }
+        }
+        return restrictions;
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/contentloader/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/LocalPrivilegeTest.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.contentloader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
+
+import org.apache.jackrabbit.oak.security.authorization.restriction.RestrictionProviderImpl;
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
+import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
+import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.apache.sling.jcr.base.util.AccessControlUtil;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class LocalPrivilegeTest {
+
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    private AccessControlManager acm;
+
+    @Before
+    public void setup() throws RepositoryException {
+        Session session = context.resourceResolver().adaptTo(Session.class);
+        acm = AccessControlUtil.getAccessControlManager(session);
+        context.registerService(new RestrictionProviderImpl());
+    }
+
+    private Privilege priv(String privilegeName) throws RepositoryException {
+        return acm.privilegeFromName(privilegeName);
+    }
+
+    private Value val(String value) {
+        return ValueFactoryImpl.getInstance().createValue(value);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#hashCode()}.
+     */
+    @Test
+    public void testHashCode() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        LocalPrivilege lp2 = new LocalPrivilege(PrivilegeConstants.JCR_WRITE);
+        assertNotEquals(lp1.hashCode(), lp2.hashCode());
+
+        LocalPrivilege lp3 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertEquals(lp1.hashCode(), lp3.hashCode());
+
+        LocalPrivilege lp4 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp4.setAllow(true);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setDeny(true);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setAllowRestrictions(null);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+        lp4.setDenyRestrictions(null);
+        assertNotEquals(lp1.hashCode(), lp4.hashCode());
+
+        LocalPrivilege lp5 = new LocalPrivilege(null);
+        assertNotEquals(lp1.hashCode(), lp5.hashCode());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#checkPrivilege(javax.jcr.security.AccessControlManager)}.
+     * @throws RepositoryException 
+     */
+    @Test
+    public void testCheckPrivilege() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp1.checkPrivilege(acm);
+        assertNotNull(lp1.getPrivilege());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getPrivilege()}.
+     * @throws RepositoryException 
+     */
+    @Test
+    public void testGetPrivilege() throws RepositoryException {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp1.checkPrivilege(acm);
+        assertEquals(priv(PrivilegeConstants.JCR_READ), lp1.getPrivilege());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getName()}.
+     */
+    @Test
+    public void testGetName() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertEquals(PrivilegeConstants.JCR_READ, lp1.getName());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#isAllow()}.
+     */
+    @Test
+    public void testIsAllow() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertFalse(lp1.isAllow());
+
+        lp1.setAllow(true);
+        assertTrue(lp1.isAllow());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#isDeny()}.
+     */
+    @Test
+    public void testIsDeny() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertFalse(lp1.isDeny());
+
+        lp1.setDeny(true);
+        assertTrue(lp1.isDeny());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setAllow(boolean)}.
+     */
+    @Test
+    public void testSetAllow() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp1.setAllow(true);
+        assertTrue(lp1.isAllow());
+        lp1.setAllow(false);
+        assertFalse(lp1.isAllow());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setDeny(boolean)}.
+     */
+    @Test
+    public void testSetDeny() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp1.setDeny(true);
+        assertTrue(lp1.isDeny());
+        lp1.setDeny(false);
+        assertFalse(lp1.isDeny());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getAllowRestrictions()}.
+     */
+    @Test
+    public void testGetAllowRestrictions() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        Set<LocalRestriction> allowRestrictions = lp1.getAllowRestrictions();
+        assertNotNull(allowRestrictions);
+        assertTrue(allowRestrictions.isEmpty());
+
+        Set<LocalRestriction> newAllowRestrictions = new HashSet<>();
+        newAllowRestrictions.add(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")));
+        lp1.setAllowRestrictions(newAllowRestrictions);
+        Set<LocalRestriction> allowRestrictions2 = lp1.getAllowRestrictions();
+        assertNotNull(allowRestrictions2);
+        assertFalse(allowRestrictions2.isEmpty());
+        assertEquals(newAllowRestrictions, allowRestrictions2);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setAllowRestrictions(java.util.Set)}.
+     */
+    @Test
+    public void testSetAllowRestrictions() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertTrue(lp1.getAllowRestrictions().isEmpty());
+
+        Set<LocalRestriction> newAllowRestrictions = new HashSet<>();
+        newAllowRestrictions.add(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")));
+        lp1.setAllowRestrictions(newAllowRestrictions);
+        assertEquals(newAllowRestrictions, lp1.getAllowRestrictions());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getDenyRestrictions()}.
+     */
+    @Test
+    public void testGetDenyRestrictions() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        Set<LocalRestriction> denyRestrictions = lp1.getDenyRestrictions();
+        assertNotNull(denyRestrictions);
+        assertTrue(denyRestrictions.isEmpty());
+
+        Set<LocalRestriction> newDenyRestrictions = new HashSet<>();
+        newDenyRestrictions.add(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")));
+        lp1.setDenyRestrictions(newDenyRestrictions);
+        Set<LocalRestriction> denyRestrictions2 = lp1.getDenyRestrictions();
+        assertNotNull(denyRestrictions2);
+        assertFalse(denyRestrictions2.isEmpty());
+        assertEquals(newDenyRestrictions, denyRestrictions2);
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setDenyRestrictions(java.util.Set)}.
+     */
+    @Test
+    public void testSetDenyRestrictions() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertTrue(lp1.getDenyRestrictions().isEmpty());
+
+        Set<LocalRestriction> newDenyRestrictions = new HashSet<>();
+        newDenyRestrictions.add(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")));
+        lp1.setDenyRestrictions(newDenyRestrictions);
+        assertEquals(newDenyRestrictions, lp1.getDenyRestrictions());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#toString()}.
+     */
+    @Test
+    public void testToString() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotNull(lp1.toString());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#equals(java.lang.Object)}.
+     */
+    @Test
+    public void testEqualsObject() {
+        LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertEquals(lp1, lp1);
+        assertNotEquals(lp1, null);
+        assertNotEquals(lp1, this);
+
+        LocalPrivilege lp2 = new LocalPrivilege(PrivilegeConstants.JCR_WRITE);
+        assertNotEquals(lp1, lp2);
+
+        LocalPrivilege lp3 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertEquals(lp1, lp3);
+
+        LocalPrivilege lp4 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp4.setAllow(true);
+        assertNotEquals(lp1, lp4);
+
+        LocalPrivilege lp5 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp5.setDeny(true);
+        assertNotEquals(lp1, lp5);
+
+        LocalPrivilege lp6 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp6.setAllowRestrictions(null);
+        assertNotEquals(lp1, lp6);
+
+        LocalPrivilege lp7 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp7.setDenyRestrictions(null);
+        assertNotEquals(lp1, lp7);
+
+        LocalPrivilege lp8 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp8.setAllowRestrictions(null);
+        LocalPrivilege lp9 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotEquals(lp8, lp9);
+
+        LocalPrivilege lp10 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp10.setDenyRestrictions(null);
+        LocalPrivilege lp11 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotEquals(lp10, lp11);
+
+        LocalPrivilege lp12 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp12.setAllowRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")))));
+        LocalPrivilege lp13 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotEquals(lp12, lp13);
+
+        LocalPrivilege lp14 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp14.setDenyRestrictions(new HashSet<>(Arrays.asList(new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello")))));
+        LocalPrivilege lp15 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotEquals(lp14, lp15);
+
+        LocalPrivilege lp16 = new LocalPrivilege(null);
+        LocalPrivilege lp17 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        assertNotEquals(lp16, lp17);
+
+        LocalPrivilege lp18 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        LocalPrivilege lp19 = new LocalPrivilege(null);
+        assertNotEquals(lp18, lp19);
+
+        LocalPrivilege lp20 = new LocalPrivilege(null);
+        LocalPrivilege lp21 = new LocalPrivilege(null);
+        assertEquals(lp20, lp21);
+
+        LocalPrivilege lp22 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp22.setAllowRestrictions(null);
+        LocalPrivilege lp23 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp23.setAllowRestrictions(null);
+        assertEquals(lp22, lp23);
+
+        LocalPrivilege lp24 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp24.setDenyRestrictions(null);
+        LocalPrivilege lp25 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
+        lp25.setDenyRestrictions(null);
+        assertEquals(lp24, lp25);
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/contentloader/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/LocalRestrictionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.jcr.contentloader;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.jcr.Value;
+import javax.jcr.ValueFactory;
+
+import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
+import org.apache.jackrabbit.value.ValueFactoryImpl;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class LocalRestrictionTest {
+
+    private Value val(String value) {
+        return ValueFactoryImpl.getInstance().createValue(value);
+    }
+    private Value[] vals(String ... value) {
+        Value[] values = new Value[value.length];
+        ValueFactory vf = ValueFactoryImpl.getInstance();
+        for (int i = 0; i < value.length; i++) {
+            values[i] = vf.createValue(value[i]);
+        }
+        return values;
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#hashCode()}.
+     */
+    @Test
+    public void testHashCode() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello2"));
+        assertNotSame(lr1.hashCode(), lr2.hashCode());
+
+        LocalRestriction lr3 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertEquals(lr1.hashCode(), lr3.hashCode());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getName()}.
+     */
+    @Test
+    public void testGetName() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertEquals(AccessControlConstants.REP_GLOB, lr1.getName());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#isMultiValue()}.
+     */
+    @Test
+    public void testIsMultiValue() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertFalse(lr1.isMultiValue());
+
+        LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, vals("item1", "item2"));
+        assertTrue(lr2.isMultiValue());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getValue()}.
+     */
+    @Test
+    public void testGetValue() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertEquals(val("/hello1"), lr1.getValue());
+
+        LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_GLOB, (Value)null);
+        assertNull(lr2.getValue());
+
+        LocalRestriction lr3 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, vals("item1", "item2"));
+        assertEquals(val("item1"), lr3.getValue());
+
+        LocalRestriction lr4 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, (Value[])new Value[0]);
+        assertNull(lr4.getValue());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getValues()}.
+     */
+    @Test
+    public void testGetValues() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, vals("item1", "item2"));
+        assertArrayEquals(vals("item1", "item2"), lr1.getValues());
+
+        LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, (Value[])null);
+        assertNull(lr2.getValues());
+
+        LocalRestriction lr3 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, new Value[0]);
+        assertArrayEquals(new Value[0], lr3.getValues());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#toString()}.
+     */
+    @Test
+    public void testToString() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertNotNull(lr1.toString());
+
+        LocalRestriction lr2 = new LocalRestriction(null, val("/hello1"));
+        assertNotNull(lr2.toString());
+    }
+
+    /**
+     * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#equals(java.lang.Object)}.
+     */
+    @Test
+    public void testEqualsObject() {
+        LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertEquals(lr1, lr1);
+        assertNotEquals(lr1, null);
+        assertNotEquals(lr1, this);
+
+        LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello2"));
+        assertNotEquals(lr1, lr2);
+
+        LocalRestriction lr3 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertEquals(lr1, lr3);
+
+        LocalRestriction lr4 = new LocalRestriction(null, val("/hello1"));
+        LocalRestriction lr5 = new LocalRestriction(null, val("/hello1"));
+        assertEquals(lr4, lr5);
+
+        LocalRestriction lr6 = new LocalRestriction(null, val("/hello1"));
+        LocalRestriction lr7 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        assertNotEquals(lr6, lr7);
+
+        LocalRestriction lr8 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        LocalRestriction lr9 = new LocalRestriction(null, val("/hello1"));
+        assertNotEquals(lr8, lr9);
+
+        LocalRestriction lr10 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        LocalRestriction lr11 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, val("/hello1"));
+        assertNotEquals(lr10, lr11);
+
+        LocalRestriction lr12 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
+        LocalRestriction lr13 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello2"));
+        assertNotEquals(lr12, lr13);
+    }
+
+}

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/JsonReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/JsonReaderTest.java
@@ -20,7 +20,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
@@ -29,6 +32,7 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonWriter;
 
 import org.apache.sling.jcr.contentloader.ContentCreator;
+import org.apache.sling.jcr.contentloader.LocalPrivilege;
 import org.apache.sling.jcr.contentloader.internal.readers.JsonReader;
 import org.jmock.Expectations;
 import org.jmock.Sequence;
@@ -446,6 +450,19 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
+    /**
+     * Return a collection that will pass the equals checking by mockit
+     * @param localPrivileges the privileges to make a collection
+     * @return collection of local privileges
+     */
+    private Collection<LocalPrivilege> toCollection(LocalPrivilege ... localPrivileges) {
+        List<LocalPrivilege> list = new ArrayList<>();
+        for (LocalPrivilege lp: localPrivileges) {
+            list.add(lp);
+        }
+        return list;
+    }
+
     @org.junit.Test
     public void testCreateAcl() throws Exception {
         String json = " { " + "\"security:acl\" : [ " + "  { " + "    \"principal\" : \"username1\","
@@ -453,17 +470,25 @@ public class JsonReaderTest {
                 + "    \"principal\" : \"groupname1\"," + "    \"granted\" : [\"jcr:read\",\"jcr:write\"]" + "  },"
                 + "  {" + "    \"principal\" : \"groupname2\"," + "    \"granted\" : [\"jcr:read\"],"
                 + "    \"denied\" : [\"jcr:write\"]," + "    \"order\" : \"first\"" + "  }" + "]" + "}";
+
+        LocalPrivilege readAllow = new LocalPrivilege("jcr:read");
+        readAllow.setAllow(true);
+        LocalPrivilege writeAllow = new LocalPrivilege("jcr:write");
+        writeAllow.setAllow(true);
+        LocalPrivilege writeDeny = new LocalPrivilege("jcr:write");
+        writeDeny.setDeny(true);
+
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
                 inSequence(mySequence);
-                allowing(creator).createAce("username1", new String[] { "jcr:read", "jcr:write" }, new String[] {},
-                        null);
+                allowing(creator).getParent();
                 inSequence(mySequence);
-                allowing(creator).createAce("groupname1", new String[] { "jcr:read", "jcr:write" }, null, null);
+                allowing(creator).createAce("username1", toCollection(readAllow, writeAllow), null);
                 inSequence(mySequence);
-                allowing(creator).createAce("groupname2", new String[] { "jcr:read" }, new String[] { "jcr:write" },
-                        "first");
+                allowing(creator).createAce("groupname1", toCollection(readAllow, writeAllow), null);
+                inSequence(mySequence);
+                allowing(creator).createAce("groupname2", toCollection(readAllow, writeDeny), "first");
                 inSequence(mySequence);
                 allowing(creator).finishNode();
                 inSequence(mySequence);
@@ -481,17 +506,25 @@ public class JsonReaderTest {
                 + "    'principal' : 'groupname1'," + "    'granted' : ['jcr:read','jcr:write']" + "  }," + "  {"
                 + "    'principal' : \"\\\"'groupname2'\"," + "    'granted' : ['jcr:read'],"
                 + "    'denied' : ['jcr:write']," + "    'order' : 'first'" + "  }" + "]" + "}";
+
+        LocalPrivilege readAllow = new LocalPrivilege("jcr:read");
+        readAllow.setAllow(true);
+        LocalPrivilege writeAllow = new LocalPrivilege("jcr:write");
+        writeAllow.setAllow(true);
+        LocalPrivilege writeDeny = new LocalPrivilege("jcr:write");
+        writeDeny.setDeny(true);
+
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
                 inSequence(mySequence);
-                allowing(creator).createAce("username1", new String[] { "jcr:read", "jcr:write" }, new String[] {},
-                        null);
+                allowing(creator).getParent();
                 inSequence(mySequence);
-                allowing(creator).createAce("groupname1", new String[] { "jcr:read", "jcr:write" }, null, null);
+                allowing(creator).createAce("username1", toCollection(readAllow, writeAllow), null);
                 inSequence(mySequence);
-                allowing(creator).createAce("\"'groupname2'", new String[] { "jcr:read" }, new String[] { "jcr:write" },
-                        "first");
+                allowing(creator).createAce("groupname1", toCollection(readAllow, writeAllow), null);
+                inSequence(mySequence);
+                allowing(creator).createAce("\"'groupname2'", toCollection(readAllow, writeDeny), "first");
                 inSequence(mySequence);
                 allowing(creator).finishNode();
                 inSequence(mySequence);

--- a/src/test/java/org/apache/sling/jcr/contentloader/it/SLING11713InitialContentIT.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/it/SLING11713InitialContentIT.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.vmOption;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.factoryConfiguration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.security.AccessControlEntry;
+import javax.jcr.security.AccessControlList;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.AccessControlPolicy;
+import javax.jcr.security.Privilege;
+
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
+import org.apache.jackrabbit.api.security.user.Authorizable;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.jcr.base.util.AccessControlUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.ModifiableCompositeOption;
+import org.ops4j.pax.exam.options.extra.VMOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.Bundle;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * SLING-11713 test ACL json input structure to be less ambiguous for restrictions
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class SLING11713InitialContentIT extends ContentloaderTestSupport {
+
+    @Configuration
+    public Option[] configuration() throws IOException {
+        final String header = DEFAULT_PATH_IN_BUNDLE + ";path:=" + CONTENT_ROOT_PATH;
+        final Multimap<String, String> content = ImmutableListMultimap.of(
+            DEFAULT_PATH_IN_BUNDLE, "SLING-11713.json"
+        );
+        final Option bundle = buildInitialContentBundle(header, content);
+        // configure the health check component
+        Option hcConfig = factoryConfiguration("org.apache.sling.jcr.contentloader.hc.BundleContentLoadedCheck")
+            .put("hc.tags", new String[] {TAG_TESTING_CONTENT_LOADING})
+            .asOption();
+        return new Option[]{
+            baseConfiguration(),
+            hcConfig,
+            bundle,
+            optionalRemoteDebug()
+        };
+    }
+
+    /**
+     * Optionally configure remote debugging on the port supplied by the "debugPort"
+     * system property.
+     */
+    protected ModifiableCompositeOption optionalRemoteDebug() {
+        VMOption option = null;
+        String property = System.getProperty("debugPort");
+        if (property != null) {
+            option = vmOption(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%s", property));
+        }
+        return composite(option);
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.sling.jcr.contentloader.it.ContentloaderTestSupport#setup()
+     */
+    @Before
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        
+        waitForContentLoaded();
+    }
+    
+    @Test
+    public void bundleStarted() {
+        final Bundle b = findBundle(BUNDLE_SYMBOLICNAME);
+        assertNotNull("Expecting bundle to be found:" + BUNDLE_SYMBOLICNAME, b);
+        assertEquals("Expecting bundle to be active:" + BUNDLE_SYMBOLICNAME, Bundle.ACTIVE, b.getState());
+    }
+
+    @Test
+    public void initialContentInstalled() throws RepositoryException {
+        final String folderPath = CONTENT_ROOT_PATH + "/SLING-11713";
+        assertTrue("Expecting initial content to be installed", session.itemExists(folderPath));
+        assertEquals("folder has node type 'sling:Folder'", "sling:Folder", session.getNode(folderPath).getPrimaryNodeType().getName());
+    }
+
+    @Test
+    public void userCreated() throws RepositoryException {
+        UserManager userManager = AccessControlUtil.getUserManager(session);
+        Authorizable authorizable = userManager.getAuthorizable("sling11713_user");
+        assertNotNull("Expecting test user to exist", authorizable);
+    }
+
+    @Test
+    public void groupCreated() throws RepositoryException {
+        UserManager userManager = AccessControlUtil.getUserManager(session);
+        Authorizable authorizable = userManager.getAuthorizable("sling11713_group");
+        assertNotNull("Expecting test group to exist", authorizable);
+        assertTrue(authorizable instanceof Group);
+        Iterator<Authorizable> members = ((Group) authorizable).getMembers();
+        assertTrue(members.hasNext());
+        Authorizable firstMember = members.next();
+        assertEquals("sling11713_user", firstMember.getID());
+    }
+
+    @Test
+    public void aceWithRestrictionsCreated() throws RepositoryException {
+        final String folderPath = CONTENT_ROOT_PATH + "/SLING-11713";
+        assertTrue("Expecting test folder to exist", session.itemExists(folderPath));
+
+        AccessControlManager accessControlManager = AccessControlUtil.getAccessControlManager(session);
+        AccessControlPolicy[] policies = accessControlManager.getPolicies(folderPath);
+        List<AccessControlEntry> allEntries = new ArrayList<AccessControlEntry>();
+        for (AccessControlPolicy accessControlPolicy : policies) {
+            if (accessControlPolicy instanceof AccessControlList) {
+                AccessControlEntry[] accessControlEntries = ((AccessControlList) accessControlPolicy).getAccessControlEntries();
+                allEntries.addAll(Arrays.asList(accessControlEntries));
+            }
+        }
+        assertEquals(7, allEntries.size());
+        Map<String, List<AccessControlEntry>> aceMap = new HashMap<>();
+        for (AccessControlEntry accessControlEntry : allEntries) {
+            List<AccessControlEntry> aceList = aceMap.computeIfAbsent(accessControlEntry.getPrincipal().getName(), name -> new ArrayList<>());
+            aceList.add(accessControlEntry);
+        }
+
+        //check ACE for sling11713_user
+        List<AccessControlEntry> aceList = aceMap.get("sling11713_user");
+        assertNotNull(aceList);
+        assertEquals(3, aceList.size());
+        assertAce(aceList.get(0), "sling11713_user",
+                false, // isAllow
+                new String[] {"jcr:write"}, // PrivilegeNames
+                new String[] {"rep:glob"}, // RestrictionNames
+                new String[] {"glob1deny"}); // RestrictionValues
+        assertAce(aceList.get(1), "sling11713_user",
+                true, // isAllow
+                new String[] {"jcr:read"}, // PrivilegeNames
+                new String[] {}, // RestrictionNames
+                new String[] {}); // RestrictionValues
+        assertAce(aceList.get(2), "sling11713_user",
+                true, // isAllow
+                new String[] {"jcr:write"}, // PrivilegeNames
+                new String[] {"rep:glob"}, // RestrictionNames
+                new String[] {"glob1allow"}); // RestrictionValues
+
+        //check ACE for sling11713_group
+        aceList = aceMap.get("sling11713_group");
+        assertNotNull(aceList);
+        assertEquals(1, aceList.size());
+        assertAce(aceList.get(0), "sling11713_group",
+                true, // isAllow
+                new String[] {"jcr:modifyAccessControl"}, // PrivilegeNames
+                new String[] {"rep:itemNames"}, // RestrictionNames
+                new String[] {"name1", "name2"}); // RestrictionValues
+
+        //check ACE for everyone
+        aceList = aceMap.get("everyone");
+        assertNotNull(aceList);
+        assertEquals(3, aceList.size());
+        assertAce(aceList.get(0), "everyone",
+                false, // isAllow
+                new String[] {"jcr:write"}, // PrivilegeNames
+                new String[] {"rep:glob"}, // RestrictionNames
+                new String[] {"glob1deny"}); // RestrictionValues
+        assertAce(aceList.get(1), "everyone",
+                true, // isAllow
+                new String[] {"jcr:read"}, // PrivilegeNames
+                new String[] {}, // RestrictionNames
+                new String[] {}); // RestrictionValues
+        assertAce(aceList.get(2), "everyone",
+                true, // isAllow
+                new String[] {"jcr:write"}, // PrivilegeNames
+                new String[] {"rep:glob"}, // RestrictionNames
+                new String[] {"glob1allow"}); // RestrictionValues
+    }
+
+    protected void assertAce(AccessControlEntry ace, String expectedPrincipal,
+            boolean isAllow, String[] expectedPrivilegeNames,
+            String[] expectedRestrictionNames, String[] expectedRestrictionValues) throws RepositoryException {
+
+        assertNotNull("Expected ACE for test principal", expectedPrincipal);
+        assertEquals(expectedPrincipal, ace.getPrincipal().getName());
+
+        Privilege[] storedPrivileges = ace.getPrivileges();
+        assertNotNull(storedPrivileges);
+        assertEquals(expectedPrivilegeNames.length, storedPrivileges.length);
+        Set<String> privilegeNamesSet = Stream.of(storedPrivileges)
+            .map(item -> item.getName())
+            .collect(Collectors.toSet());
+        for (String pn : expectedPrivilegeNames) {
+            assertTrue("Expecting privilege: " + pn, privilegeNamesSet.contains(pn));
+        }
+
+        assertTrue(ace instanceof JackrabbitAccessControlEntry);
+        JackrabbitAccessControlEntry jace = (JackrabbitAccessControlEntry) ace;
+        assertEquals(isAllow, jace.isAllow());
+
+        //check restrictions
+        String[] storedRestrictionNames = jace.getRestrictionNames();
+        assertNotNull(storedRestrictionNames);
+        assertEquals(expectedRestrictionNames.length, storedRestrictionNames.length);
+        Set<String> restrictionNamesSet = Stream.of(storedRestrictionNames)
+            .collect(Collectors.toSet());
+        for (String rn : expectedRestrictionNames) {
+            assertTrue("Expecting restriction: " + rn, restrictionNamesSet.contains(rn));
+        }
+
+        if (expectedRestrictionValues.length > 0) {
+            Value[] storedRestrictionValues = jace.getRestrictions(storedRestrictionNames[0]);
+            assertNotNull(storedRestrictionValues);
+            assertEquals(expectedRestrictionValues.length, storedRestrictionValues.length);
+            Set<String> restrictionValuesSet = Stream.of(storedRestrictionValues)
+                    .map(item -> {
+                        try {
+                            return item.getString();
+                        } catch (IllegalStateException | RepositoryException e) {
+                            // should never get here
+                            return null;
+                        }
+                    })
+                    .collect(Collectors.toSet());
+            for (String rv : expectedRestrictionValues) {
+                assertTrue("Expecting restriction value: " + rv, restrictionValuesSet.contains(rv));
+            }
+        }
+    }
+}

--- a/src/test/resources/initial-content/SLING-11713.json
+++ b/src/test/resources/initial-content/SLING-11713.json
@@ -1,0 +1,63 @@
+{
+    "jcr:primaryType" : "sling:Folder",
+    "security:principals": [
+        { 
+            "name": "sling11713_user", 
+            "password": "mypassword"
+        },
+        { 
+            "name": "sling11713_group", 
+            "isgroup": true,
+            "members":[
+               "sling11713_user"
+            ]
+        }
+    ],
+    "security:acl": [
+        { 
+            "principal": "everyone", 
+            "granted": [
+                "jcr:read"
+            ],
+            "privileges":{
+                "jcr:write":{
+                    "allow":{
+                        "rep:glob":"glob1allow"
+                    },
+                    "deny":{
+                        "rep:glob":"glob1deny"
+                    }
+                }
+            }
+        },
+        { 
+            "principal": "sling11713_user", 
+            "privileges":{
+                "jcr:read": {
+                    "allow": true
+                },
+                "jcr:write":{
+                    "allow":{
+                        "rep:glob":"glob1allow"
+                    },
+                    "deny":{
+                        "rep:glob":"glob1deny"
+                    }
+                }
+            }
+        },
+        { 
+            "principal": "sling11713_group", 
+            "privileges":{
+                "jcr:modifyAccessControl":{
+                    "allow": {
+                        "rep:itemNames": [
+                            "name1",
+                            "name2"
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
to be less ambiguous for restrictions

The restriction details in the security:acl contentloader json input can be ambiguous in some situations.

This is the ContentLoader equivalent for what was done for [SLING-11243](https://issues.apache.org/jira/browse/SLING-11243) and [SLING-11233](https://issues.apache.org/jira/browse/SLING-11233)

Expected:

The JSON structure of the security:acl entries should be enhanced to make it more clear. 

For example, replace the "granted/denied/restrictions" items with a "privileges" structure whose items are the granted or denied privileges.  Each privilege has a "deny" and/or "allow" child whose value is either true (no restrictions) or an array of restrictions + values.