### PR TITLE
SLING-11891 SlingPostServlet: Support importing binary data from json

### DIFF
--- a/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
+++ b/src/main/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreator.java
@@ -73,6 +73,7 @@ import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.util.ISO8601;
+import org.apache.jackrabbit.value.ValueHelper;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.jcr.contentloader.ContentCreator;
 import org.apache.sling.jcr.contentloader.ContentImportListener;
@@ -321,6 +322,13 @@ public class DefaultContentCreator implements ContentCreator {
     public void createProperty(String name, int propertyType, String value) throws RepositoryException {
         appliedSet.add(name);
         final Node node = this.parentNodeStack.peek();
+        if(name.startsWith(":") && propertyType != PropertyType.LONG){
+            // JSON Renderer in Sling GET Servlet marks binary properties with an initial colon in their name.
+            // By default, it dumps the length and not the data and the property type is LONG.
+            // If the property type is not LONG it means the json carries base64 encoded binary value.
+            name = name.substring(1);
+            propertyType = PropertyType.BINARY;
+        }
         // check if the property already exists and isPropertyOverwrite() is false,
         // don't overwrite it in this case
         if (node.hasProperty(name) && !this.configuration.isPropertyOverwrite() && !node.getProperty(name).isNew()) {
@@ -348,6 +356,15 @@ public class DefaultContentCreator implements ContentCreator {
         } else if (propertyType == PropertyType.DATE) {
             checkoutIfNecessary(node);
             node.setProperty(name, ISO8601.parse(value));
+            if (this.importListener != null) {
+                this.importListener.onCreate(node.getProperty(name).getPath());
+            }
+        } else if (propertyType == PropertyType.BINARY) {
+            checkoutIfNecessary(node);
+            // Re-use the same code that Jackrabbit uses to import from JCR XML.
+            // The decodeBlanks flag can be ignored since base64-encoded data cannot contain encoded space characters
+            Value binaryValue = ValueHelper.deserialize(value, propertyType, true, node.getSession().getValueFactory());
+            node.setProperty(name, binaryValue);
             if (this.importListener != null) {
                 this.importListener.onCreate(node.getProperty(name).getPath());
             }

--- a/src/test/java/org/apache/sling/jcr/contentloader/it/BinaryContentIT.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/it/BinaryContentIT.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.contentloader.it;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.Bundle;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.cm.ConfigurationAdminOptions.factoryConfiguration;
+
+/**
+ * Test importing binary data
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class BinaryContentIT extends ContentloaderTestSupport {
+
+    @Configuration
+    public Option[] configuration() throws IOException {
+        final String header = DEFAULT_PATH_IN_BUNDLE + ";path:=" + CONTENT_ROOT_PATH;
+        final Multimap<String, String> content = ImmutableListMultimap.of(
+                DEFAULT_PATH_IN_BUNDLE, "binary-data.json"
+        );
+        final Option bundle = buildInitialContentBundle(header, content);
+        // configure the health check component
+        Option hcConfig = factoryConfiguration("org.apache.sling.jcr.contentloader.hc.BundleContentLoadedCheck")
+                .put("hc.tags", new String[]{TAG_TESTING_CONTENT_LOADING})
+                .asOption();
+        return new Option[]{
+                baseConfiguration(),
+                hcConfig,
+                bundle
+        };
+    }
+
+    /* (non-Javadoc)
+     * @see org.apache.sling.jcr.contentloader.it.ContentloaderTestSupport#setup()
+     */
+    @Before
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        waitForContentLoaded();
+    }
+
+    @Test
+    public void bundleStarted() {
+        final Bundle b = findBundle(BUNDLE_SYMBOLICNAME);
+        assertNotNull("Expecting bundle to be found:" + BUNDLE_SYMBOLICNAME, b);
+        assertEquals("Expecting bundle to be active:" + BUNDLE_SYMBOLICNAME, Bundle.ACTIVE, b.getState());
+    }
+
+    @Test
+    public void importBinaryData() throws RepositoryException, IOException {
+        final String imagePath = CONTENT_ROOT_PATH + "/binary-data";
+        assertTrue("file node " + imagePath + " exists", session.itemExists(imagePath));
+        Node image = session.getNode(imagePath);
+
+        Node ntFile = image.getNode("file");
+        assertEquals("file has node type 'nt:file'", "nt:file", ntFile.getPrimaryNodeType().getName());
+
+        Node ntResource = ntFile.getNode("jcr:content");
+        assertEquals("jcr:content has node type 'nt:resource'", "nt:resource", ntResource.getPrimaryNodeType().getName());
+        assertTrue("jcr:content has property 'jcr:data'",  ntResource.hasProperty("jcr:data"));
+
+        Property property = ntResource.getProperty("jcr:data");
+        assertEquals("jcr:data  is a binary property", PropertyType.BINARY, property.getType());
+
+        // read the data, encode it to base64 and assert it matches the input json
+        InputStream inputStream = property.getBinary().getStream();
+        byte[] bytes = IOUtils.toByteArray(inputStream);
+        String base64  = Base64.getEncoder().encodeToString(bytes);
+        assertEquals("binary data is the same after round-trip", "iVBORw0KGgoA", base64);
+    }
+
+}

--- a/src/test/resources/initial-content/binary-data.json
+++ b/src/test/resources/initial-content/binary-data.json
@@ -1,0 +1,11 @@
+{
+  "jcr:primaryType": "nt:unstructured",
+  "file": {
+    "jcr:primaryType": "nt:file",
+    "jcr:content": {
+      "jcr:primaryType": "nt:resource",
+      "jcr:mimeType": "image/png",
+      ":jcr:data": "iVBORw0KGgoA"
+    }
+  }
+}


### PR DESCRIPTION
The PR adds support for importing binary data in SlingPostServlet

See https://issues.apache.org/jira/browse/SLING-11891