### PR TITLE
SLING-13160 Migrate to junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         </dependency>
         <dependency>
             <groupId>org.jmock</groupId>
-            <artifactId>jmock-junit4</artifactId>
+            <artifactId>jmock-junit5</artifactId>
             <version>2.13.1</version>
             <scope>test</scope>
         </dependency>
@@ -272,7 +272,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
             <version>3.5.6</version>
             <scope>test</scope>
         </dependency>
@@ -286,13 +286,24 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
             <version>4.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Engine for JUnit 4 tests (paxexam) -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/jcr/contentloader/ContentCreatorTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/ContentCreatorTest.java
@@ -32,18 +32,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * for an old impl that does not provide an implementation
  * for those methods
  */
-public class ContentCreatorTest {
+class ContentCreatorTest {
 
     private ContentCreator contentCreator = new ContentCreatorOldImpl();
 
     @Test
-    public void testCreateAce1() throws RepositoryException {
+    void testCreateAce1() {
         assertThrows(UnsupportedOperationException.class, () -> contentCreator.createAce(null, null, null));
     }
 
     @Deprecated
     @Test
-    public void testCreateAce2() throws RepositoryException {
+    void testCreateAce2() {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> contentCreator.createAce(null, null, null, null, null, null, null));

--- a/src/test/java/org/apache/sling/jcr/contentloader/ContentCreatorTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/ContentCreatorTest.java
@@ -23,7 +23,9 @@ import javax.jcr.RepositoryException;
 import java.io.InputStream;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests to verify the ContentCreator default methods
@@ -34,15 +36,17 @@ public class ContentCreatorTest {
 
     private ContentCreator contentCreator = new ContentCreatorOldImpl();
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testCreateAce1() throws RepositoryException {
-        contentCreator.createAce(null, null, null);
+        assertThrows(UnsupportedOperationException.class, () -> contentCreator.createAce(null, null, null));
     }
 
     @Deprecated
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testCreateAce2() throws RepositoryException {
-        contentCreator.createAce(null, null, null, null, null, null, null);
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> contentCreator.createAce(null, null, null, null, null, null, null));
     }
 
     /**

--- a/src/test/java/org/apache/sling/jcr/contentloader/LocalPrivilegeTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/LocalPrivilegeTest.java
@@ -34,29 +34,30 @@ import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
 import org.apache.sling.jcr.base.util.AccessControlUtil;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  */
-public class LocalPrivilegeTest {
+@ExtendWith(SlingContextExtension.class)
+class LocalPrivilegeTest {
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private AccessControlManager acm;
 
-    @Before
-    public void setup() throws RepositoryException {
+    @BeforeEach
+    void setup() throws RepositoryException {
         Session session = context.resourceResolver().adaptTo(Session.class);
         acm = AccessControlUtil.getAccessControlManager(session);
         context.registerService(new RestrictionProviderImpl());
@@ -74,7 +75,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#hashCode()}.
      */
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         LocalPrivilege lp2 = new LocalPrivilege(PrivilegeConstants.JCR_WRITE);
         assertNotEquals(lp1.hashCode(), lp2.hashCode());
@@ -101,7 +102,7 @@ public class LocalPrivilegeTest {
      * @throws RepositoryException
      */
     @Test
-    public void testCheckPrivilege() throws RepositoryException {
+    void testCheckPrivilege() throws RepositoryException {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         lp1.checkPrivilege(acm);
         assertNotNull(lp1.getPrivilege());
@@ -112,7 +113,7 @@ public class LocalPrivilegeTest {
      * @throws RepositoryException
      */
     @Test
-    public void testGetPrivilege() throws RepositoryException {
+    void testGetPrivilege() throws RepositoryException {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         lp1.checkPrivilege(acm);
         assertEquals(priv(PrivilegeConstants.JCR_READ), lp1.getPrivilege());
@@ -122,7 +123,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getName()}.
      */
     @Test
-    public void testGetName() {
+    void testGetName() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertEquals(PrivilegeConstants.JCR_READ, lp1.getName());
     }
@@ -131,7 +132,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#isAllow()}.
      */
     @Test
-    public void testIsAllow() {
+    void testIsAllow() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertFalse(lp1.isAllow());
 
@@ -143,7 +144,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#isDeny()}.
      */
     @Test
-    public void testIsDeny() {
+    void testIsDeny() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertFalse(lp1.isDeny());
 
@@ -155,7 +156,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setAllow(boolean)}.
      */
     @Test
-    public void testSetAllow() {
+    void testSetAllow() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         lp1.setAllow(true);
         assertTrue(lp1.isAllow());
@@ -167,7 +168,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setDeny(boolean)}.
      */
     @Test
-    public void testSetDeny() {
+    void testSetDeny() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         lp1.setDeny(true);
         assertTrue(lp1.isDeny());
@@ -179,7 +180,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getAllowRestrictions()}.
      */
     @Test
-    public void testGetAllowRestrictions() {
+    void testGetAllowRestrictions() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         Set<LocalRestriction> allowRestrictions = lp1.getAllowRestrictions();
         assertNotNull(allowRestrictions);
@@ -198,7 +199,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setAllowRestrictions(java.util.Set)}.
      */
     @Test
-    public void testSetAllowRestrictions() {
+    void testSetAllowRestrictions() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertTrue(lp1.getAllowRestrictions().isEmpty());
 
@@ -212,7 +213,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#getDenyRestrictions()}.
      */
     @Test
-    public void testGetDenyRestrictions() {
+    void testGetDenyRestrictions() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         Set<LocalRestriction> denyRestrictions = lp1.getDenyRestrictions();
         assertNotNull(denyRestrictions);
@@ -231,7 +232,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#setDenyRestrictions(java.util.Set)}.
      */
     @Test
-    public void testSetDenyRestrictions() {
+    void testSetDenyRestrictions() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertTrue(lp1.getDenyRestrictions().isEmpty());
 
@@ -245,7 +246,7 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#toString()}.
      */
     @Test
-    public void testToString() {
+    void testToString() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertNotNull(lp1.toString());
     }
@@ -254,10 +255,10 @@ public class LocalPrivilegeTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalPrivilege#equals(java.lang.Object)}.
      */
     @Test
-    public void testEqualsObject() {
+    void testEqualsObject() {
         LocalPrivilege lp1 = new LocalPrivilege(PrivilegeConstants.JCR_READ);
         assertEquals(lp1, lp1);
-        assertNotEquals(lp1, null);
+        assertNotNull(lp1);
         assertNotEquals(lp1, this);
 
         LocalPrivilege lp2 = new LocalPrivilege(PrivilegeConstants.JCR_WRITE);

--- a/src/test/java/org/apache/sling/jcr/contentloader/LocalRestrictionTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/LocalRestrictionTest.java
@@ -25,16 +25,16 @@ import javax.jcr.ValueFormatException;
 
 import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.value.ValueFactoryImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
@@ -65,7 +65,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#hashCode()}.
      */
     @Test
-    public void testHashCode() throws ValueFormatException {
+    void testHashCode() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello2"));
         assertNotSame(lr1.hashCode(), lr2.hashCode());
@@ -86,7 +86,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getName()}.
      */
     @Test
-    public void testGetName() throws ValueFormatException {
+    void testGetName() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         assertEquals(AccessControlConstants.REP_GLOB, lr1.getName());
     }
@@ -95,7 +95,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#isMultiValue()}.
      */
     @Test
-    public void testIsMultiValue() throws ValueFormatException {
+    void testIsMultiValue() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         assertFalse(lr1.isMultiValue());
 
@@ -107,7 +107,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getValue()}.
      */
     @Test
-    public void testGetValue() throws ValueFormatException {
+    void testGetValue() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         assertEquals(val("/hello1"), lr1.getValue());
 
@@ -125,7 +125,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#getValues()}.
      */
     @Test
-    public void testGetValues() throws ValueFormatException {
+    void testGetValues() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_ITEM_NAMES, vals("item1", "item2"));
         assertArrayEquals(vals("item1", "item2"), lr1.getValues());
 
@@ -140,7 +140,7 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#toString()}.
      */
     @Test
-    public void testToString() throws ValueFormatException {
+    void testToString() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         assertNotNull(lr1.toString());
 
@@ -152,10 +152,10 @@ public class LocalRestrictionTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.LocalRestriction#equals(java.lang.Object)}.
      */
     @Test
-    public void testEqualsObject() throws ValueFormatException {
+    void testEqualsObject() throws ValueFormatException {
         LocalRestriction lr1 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello1"));
         assertEquals(lr1, lr1);
-        assertNotEquals(lr1, null);
+        assertNotNull(lr1);
         assertNotEquals(lr1, this);
 
         LocalRestriction lr2 = new LocalRestriction(AccessControlConstants.REP_GLOB, val("/hello2"));

--- a/src/test/java/org/apache/sling/jcr/contentloader/PathEntryTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/PathEntryTest.java
@@ -26,25 +26,25 @@ import java.util.Map;
 
 import org.apache.sling.commons.osgi.ManifestHeader;
 import org.jmock.Expectations;
-import org.jmock.integration.junit4.JUnitRuleMockery;
-import org.junit.Rule;
-import org.junit.Test;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.Bundle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PathEntryTest {
+class PathEntryTest {
     final String pathEntryPath = "/test/path";
 
-    @Rule
-    public final JUnitRuleMockery mockery = new JUnitRuleMockery();
+    @RegisterExtension
+    public final JUnit5Mockery mockery = new JUnit5Mockery();
 
     @Test
-    public void testGetContentPaths() {
+    void testGetContentPaths() {
         final Bundle bundle = mockery.mock(Bundle.class);
         final Dictionary<String, String> dict = new Hashtable<>();
         dict.put("Bnd-LastModified", "1258555936230");
@@ -80,7 +80,7 @@ public class PathEntryTest {
     }
 
     @Test
-    public void testConstructorSetup() throws NoSuchFieldException {
+    void testConstructorSetup() {
         final String overwriteDirective = "true";
         final String overwritePropertiesDirective = "true";
         final String uninstallDirective = "true";

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderListenerTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderListenerTest.java
@@ -35,10 +35,11 @@ import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
 import org.apache.sling.jcr.contentloader.internal.readers.ZipReader;
 import org.apache.sling.testing.mock.osgi.MockBundle;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleEvent;
 
@@ -48,23 +49,23 @@ import static org.apache.sling.jcr.contentloader.internal.BundleContentLoaderLis
 import static org.apache.sling.jcr.contentloader.internal.BundleContentLoaderListener.PROPERTY_UNINSTALL_PATHS;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BundleContentLoaderListenerTest {
+@ExtendWith(SlingContextExtension.class)
+class BundleContentLoaderListenerTest {
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private BundleContentLoaderListener underTest;
     private BundleContentLoader contentLoader;
     private Session session;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         // prepare content readers
         context.registerInjectActivateService(JsonReader.class);
         context.registerInjectActivateService(OrderedJsonReader.class);
@@ -87,7 +88,7 @@ public class BundleContentLoaderListenerTest {
     // And more affects BundleContentLoader than BundleContentLoaderListener
 
     @Test
-    public void testBundleResolvedBundleChanged() {
+    void testBundleResolvedBundleChanged() {
         final Bundle bundle = createNewBundle();
         @SuppressWarnings("unchecked")
         final List<Bundle> delayedBundles =
@@ -113,7 +114,7 @@ public class BundleContentLoaderListenerTest {
     // -------BundleContentLoaderListener#bundleChanged(BundleEvent)-------//
 
     @Test
-    public void getContentInfoFromLockedNode() throws RepositoryException {
+    void getContentInfoFromLockedNode() throws RepositoryException {
         final Bundle bundle = createNewBundle();
         final Node bcNode = (Node) session.getItem(BundleContentLoaderListener.BUNDLE_CONTENT_NODE);
         bcNode.addNode(bundle.getSymbolicName()).addMixin("mix:lockable");
@@ -130,7 +131,7 @@ public class BundleContentLoaderListenerTest {
     }
 
     @Test
-    public void getContentInfoFromNotLockableNode() throws RepositoryException {
+    void getContentInfoFromNotLockableNode() throws RepositoryException {
         final Bundle bundle = createNewBundle();
         final Node bcNode = (Node) session.getItem(BundleContentLoaderListener.BUNDLE_CONTENT_NODE);
         bcNode.addNode(bundle.getSymbolicName()); // Node without lockable mixin
@@ -140,7 +141,7 @@ public class BundleContentLoaderListenerTest {
     }
 
     @Test
-    public void getContentInfo() throws RepositoryException {
+    void getContentInfo() throws RepositoryException {
         final Bundle bundle = createNewBundle();
         final Node bcNode = (Node) session.getItem(BundleContentLoaderListener.BUNDLE_CONTENT_NODE);
         final Node bundleContent = bcNode.addNode(bundle.getSymbolicName());
@@ -166,7 +167,7 @@ public class BundleContentLoaderListenerTest {
     // -------BundleContentLoaderListener#contentIsUninstalled(Session, Bundle)-------//
 
     @Test
-    public void testContentIsUninstalled() throws RepositoryException {
+    void testContentIsUninstalled() throws RepositoryException {
         final Bundle bundle = createNewBundle();
         final Node bcNode = session.getNode(BUNDLE_CONTENT_NODE).addNode(bundle.getSymbolicName());
 
@@ -181,14 +182,14 @@ public class BundleContentLoaderListenerTest {
     // -------BundleContentLoaderListener#getMimeType(String)-------//
 
     @Test
-    public void testMimeTypeService() {
+    void testMimeTypeService() {
         assertEquals("audio/mpeg", underTest.getMimeType("test.mp3"));
     }
 
     // -------BundleContentLoaderListener#getMimeType(String)-------//
 
     @Test
-    public void getSessionForWorkspace() throws RepositoryException {
+    void getSessionForWorkspace() throws RepositoryException {
         assertNotNull(underTest.getSession(null));
     }
 

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/BundleContentLoaderTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.sling.jcr.contentloader.internal;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.NamespaceException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
@@ -47,12 +45,13 @@ import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
 import org.apache.sling.jcr.contentloader.internal.readers.ZipReader;
 import org.apache.sling.testing.mock.osgi.MockBundle;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 
@@ -61,13 +60,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(SlingContextExtension.class)
 public class BundleContentLoaderTest {
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private BundleContentLoaderListener bundleHelper;
@@ -76,8 +75,8 @@ public class BundleContentLoaderTest {
 
     private static final String CUSTOM_PRIVILEGE_NAME = "customPrivilege";
 
-    @Before
-    public void prepareContentLoader() throws Exception {
+    @BeforeEach
+    void prepareContentLoader() {
         // prepare content readers
         context.registerInjectActivateService(JsonReader.class);
         context.registerInjectActivateService(OrderedJsonReader.class);
@@ -93,8 +92,7 @@ public class BundleContentLoaderTest {
         whiteboard = context.getService(ContentReaderWhiteboard.class);
     }
 
-    private static Privilege getOrRegisterCustomPrivilege(Session session)
-            throws AccessDeniedException, NamespaceException, RepositoryException {
+    private static Privilege getOrRegisterCustomPrivilege(Session session) throws RepositoryException {
         // register custom privilege
         Workspace wsp = session.getWorkspace();
         if (!(wsp instanceof JackrabbitWorkspace)) {
@@ -142,29 +140,29 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentOverwriteWithoutPath() throws Exception {
+    void loadContentOverwriteWithoutPath() throws Exception {
         AccessControlEntry[] expectedAces = createFolderNodeAndACL("/apps/child");
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
         Bundle mockBundle = newBundleWithInitialContent(context, "SLING-INF2;overwrite:=true");
         contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
         Resource imported = context.resourceResolver().getResource("/apps/sling/validation/content");
-        assertNull("Resource was unexpectedly imported", imported);
+        assertNull(imported, "Resource was unexpectedly imported");
         assertFolderNodeAndACL("/apps/child", expectedAces);
     }
 
     @Test
-    public void loadContentOverwriteWithRootPath() throws Exception {
+    void loadContentOverwriteWithRootPath() throws Exception {
         AccessControlEntry[] expectedAces = createFolderNodeAndACL("/apps/child");
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
         Bundle mockBundle = newBundleWithInitialContent(context, "SLING-INF2;overwrite:=true;path:=/");
         contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), mockBundle, false);
         Resource imported = context.resourceResolver().getResource("/apps/sling/validation/content");
-        assertNull("Resource was unexpectedly imported", imported);
+        assertNull(imported, "Resource was unexpectedly imported");
         assertFolderNodeAndACL("/apps/child", expectedAces);
     }
 
     @Test
-    public void loadContentOverwriteWith2ndLevelPath() throws Exception {
+    void loadContentOverwriteWith2ndLevelPath() throws Exception {
         /*AccessControlEntry[] expectedAces =*/ createFolderNodeAndACL("/apps/child");
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
         Bundle mockBundle = newBundleWithInitialContent(context, "SLING-INF2/apps;overwrite:=true;path:=/apps");
@@ -177,7 +175,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentWithSpecificPath() throws Exception {
+    void loadContentWithSpecificPath() {
 
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
 
@@ -192,7 +190,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentFromFilePathEntry() throws Exception {
+    void loadContentFromFilePathEntry() {
 
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
 
@@ -208,7 +206,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentWithExcludes() throws Exception {
+    void loadContentWithExcludes() {
 
         BundleContentLoader contentLoader =
                 new BundleContentLoader(bundleHelper, whiteboard, new BundleContentLoaderConfiguration() {
@@ -237,7 +235,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentWithNullValue() throws Exception {
+    void loadContentWithNullValue() {
 
         BundleContentLoader contentLoader =
                 new BundleContentLoader(bundleHelper, whiteboard, new BundleContentLoaderConfiguration() {
@@ -266,7 +264,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentWithIncludes() throws Exception {
+    void loadContentWithIncludes() {
 
         BundleContentLoader contentLoader =
                 new BundleContentLoader(bundleHelper, whiteboard, new BundleContentLoaderConfiguration() {
@@ -295,7 +293,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void loadContentWithRootPath() throws Exception {
+    void loadContentWithRootPath() {
 
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
 
@@ -310,8 +308,8 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    @Ignore("TODO - unregister or somehow ignore the XmlReader component for this test")
-    public void loadXmlAsIs() throws Exception {
+    @Disabled("TODO - unregister or somehow ignore the XmlReader component for this test")
+    void loadXmlAsIs() {
 
         BundleContentLoader contentLoader = new BundleContentLoader(bundleHelper, whiteboard, null);
 
@@ -335,7 +333,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void testDescriptorGetSetUrl() throws Exception {
+    void testDescriptorGetSetUrl() {
         BundleContentLoader.Descriptor desc = new BundleContentLoader.Descriptor();
 
         assertNull(desc.getUrl());
@@ -345,7 +343,7 @@ public class BundleContentLoaderTest {
     }
 
     @Test
-    public void testDescriptorGetSetContentReader() throws Exception {
+    void testDescriptorGetSetContentReader() {
         BundleContentLoader.Descriptor desc = new BundleContentLoader.Descriptor();
 
         assertNull(desc.getContentReader());
@@ -372,7 +370,7 @@ public class BundleContentLoaderTest {
             format.append("  ");
         }
         format.append("%s [%s]%n");
-        String name = resource.getName().length() == 0 ? "/" : resource.getName();
+        String name = resource.getName().isEmpty() ? "/" : resource.getName();
         System.out.format(format.toString(), name, resource.getResourceType());
         currentDepth++;
         if (currentDepth > maxDepth) {

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/ContentLoaderWebConsolePluginTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/ContentLoaderWebConsolePluginTest.java
@@ -30,35 +30,36 @@ import java.util.Map;
 
 import org.apache.sling.jcr.contentloader.PathEntry;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingJakartaHttpServletResponse;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 /**
  *
  */
-public class ContentLoaderWebConsolePluginTest {
+@ExtendWith(SlingContextExtension.class)
+class ContentLoaderWebConsolePluginTest {
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
     private ContentLoaderWebConsolePlugin plugin;
     private BundleHelper mockBundleHelper;
 
-    @Before
-    public void beforeEach() {
+    @BeforeEach
+    void beforeEach() {
         mockBundleHelper = context.registerService(BundleHelper.class, Mockito.mock(BundleHelper.class));
 
         plugin = context.registerInjectActivateService(ContentLoaderWebConsolePlugin.class);
@@ -71,7 +72,7 @@ public class ContentLoaderWebConsolePluginTest {
      * Test method for {@link org.apache.sling.jcr.contentloader.internal.ContentLoaderWebConsolePlugin#service(jakarta.servlet.ServletRequest, jakarta.servlet.ServletResponse)}.
      */
     @Test
-    public void testService() throws IOException, RepositoryException {
+    void testService() throws IOException, RepositoryException {
         // simulate deployed bundles
         plugin.context = Mockito.spy(plugin.context);
         Bundle mockBundle1 = mockBundle(1, "test.bundle1", Map.of());
@@ -122,7 +123,7 @@ public class ContentLoaderWebConsolePluginTest {
     }
 
     @Test
-    public void testServiceWithRepositoryException() throws IOException, RepositoryException {
+    void testServiceWithRepositoryException() throws IOException, RepositoryException {
         // simulate exception thrown during login
         plugin.repository = Mockito.spy(plugin.repository);
         Mockito.doThrow(RepositoryException.class).when(plugin.repository).loginService(null, null);
@@ -132,7 +133,7 @@ public class ContentLoaderWebConsolePluginTest {
         plugin.service(req, resp);
         final String outputAsString = resp.getOutputAsString();
         assertTrue(
-                "Expected logged error message", outputAsString.contains("Error accessing the underlying repository"));
+                outputAsString.contains("Error accessing the underlying repository"), "Expected logged error message");
     }
 
     /**
@@ -140,7 +141,7 @@ public class ContentLoaderWebConsolePluginTest {
      * org.apache.sling.jcr.contentloader.internal.ContentLoaderWebConsolePlugin#getResource(java.lang.String)}.
      */
     @Test
-    public void testGetResource() throws SecurityException, IllegalArgumentException {
+    void testGetResource() throws SecurityException, IllegalArgumentException {
         final URL value1 = ReflectionTools.invokeMethodWithReflection(
                 plugin, "getResource", new Class[] {String.class}, URL.class, new Object[] {"/invalid"});
         assertNull(value1);

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/CreateNodeTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/CreateNodeTest.java
@@ -26,19 +26,21 @@ import java.util.UUID;
 
 import org.apache.sling.jcr.contentloader.ContentReader;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.AUTO_CHECKOUT;
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.OVERWRITE_NODE;
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.OVERWRITE_PROPERTIES;
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.createImportOptions;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** TODO might need to consolidate this with DefaultContentCreatorTest */
+@ExtendWith(SlingContextExtension.class)
 public class CreateNodeTest {
 
     private DefaultContentCreator contentCreator;
@@ -47,15 +49,14 @@ public class CreateNodeTest {
     private static final String DEFAULT_NAME = "default-name";
     public static final String MIX_VERSIONABLE = "mix:versionable";
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private final String uniqueId() {
         return getClass().getSimpleName() + UUID.randomUUID();
     }
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         session = context.resourceResolver().adaptTo(Session.class);
         contentCreator = new DefaultContentCreator(null);
         contentCreator.init(
@@ -67,11 +68,11 @@ public class CreateNodeTest {
     }
 
     @Test
-    public void testCreateNode() throws Exception {
+    void testCreateNode() throws Exception {
         contentCreator.prepareParsing(testRoot, DEFAULT_NAME);
         final String name = uniqueId();
-        assertFalse("Expecting " + name + " child node to be absent before test", testRoot.hasNode(name));
+        assertFalse(testRoot.hasNode(name), "Expecting " + name + " child node to be absent before test");
         contentCreator.createNode(name, null, null);
-        assertTrue("Expecting " + name + " child node to be created", testRoot.hasNode(name));
+        assertTrue(testRoot.hasNode(name), "Expecting " + name + " child node to be created");
     }
 }

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreatorTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/DefaultContentCreatorTest.java
@@ -47,13 +47,14 @@ import org.apache.sling.jcr.contentloader.ContentReader;
 import org.apache.sling.jcr.contentloader.LocalPrivilege;
 import org.apache.sling.jcr.contentloader.LocalRestriction;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JUnit4Mockery;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.AUTO_CHECKOUT;
 import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.CHECK_IN;
@@ -64,27 +65,30 @@ import static org.apache.sling.jcr.contentloader.ImportOptionsFactory.createImpo
 import static org.apache.sling.jcr.contentloader.LocalRestrictionTest.val;
 import static org.apache.sling.jcr.contentloader.LocalRestrictionTest.vals;
 import static org.apache.sling.jcr.contentloader.it.SLING11713InitialContentIT.assertAce;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DefaultContentCreatorTest {
+@ExtendWith(SlingContextExtension.class)
+class DefaultContentCreatorTest {
 
     static final String DEFAULT_NAME = "default-name";
-    final Mockery mockery = new JUnit4Mockery();
+
+    @RegisterExtension
+    final JUnit5Mockery mockery = new JUnit5Mockery();
+
     DefaultContentCreator contentCreator;
 
     Session session;
     Node parentNode;
     Property prop;
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         session = context.resourceResolver().adaptTo(Session.class);
         contentCreator = new DefaultContentCreator(null);
         contentCreator.init(
@@ -96,7 +100,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void willRewriteUndefinedPropertyType() throws RepositoryException {
+    void willRewriteUndefinedPropertyType() throws RepositoryException {
         parentNode = mockery.mock(Node.class);
         prop = mockery.mock(Property.class);
         contentCreator.init(
@@ -121,7 +125,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void willNotRewriteUndefinedPropertyType() throws RepositoryException {
+    void willNotRewriteUndefinedPropertyType() throws RepositoryException {
         parentNode = mockery.mock(Node.class);
         prop = mockery.mock(Property.class);
         contentCreator.init(createImportOptions(AUTO_CHECKOUT), new HashMap<String, ContentReader>(), null, null);
@@ -141,7 +145,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testDoesNotCreateProperty() throws RepositoryException {
+    void testDoesNotCreateProperty() throws RepositoryException {
         final String propertyName = "foo";
         prop = mockery.mock(Property.class);
         parentNode = mockery.mock(Node.class);
@@ -165,7 +169,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testCreateReferenceProperty() throws RepositoryException {
+    void testCreateReferenceProperty() throws RepositoryException {
         final String propertyName = "foo";
         final String propertyValue = "bar";
         final String rootNodeName = uniqueId();
@@ -207,7 +211,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testCreateFalseCheckedOutPreperty() throws RepositoryException {
+    void testCreateFalseCheckedOutPreperty() throws RepositoryException {
         parentNode = mockery.mock(Node.class);
 
         this.mockery.checking(new Expectations() {
@@ -228,7 +232,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testCreateTrueCheckedOutPreperty() throws RepositoryException {
+    void testCreateTrueCheckedOutPreperty() throws RepositoryException {
         parentNode = mockery.mock(Node.class);
 
         this.mockery.checking(new Expectations() {
@@ -248,7 +252,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testCreateDateProperty() throws RepositoryException {
+    void testCreateDateProperty() throws RepositoryException {
         final String propertyName = "dateProp";
         final String propertyValue = "2012-10-01T09:45:00.000+02:00";
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
@@ -275,7 +279,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void testCreatePropertyWithNewPropertyType() throws RepositoryException {
+    void testCreatePropertyWithNewPropertyType() throws RepositoryException {
         final String propertyName = "foo";
         final String propertyValue = "bar";
         final Integer propertyType = -1;
@@ -305,7 +309,7 @@ public class DefaultContentCreatorTest {
     // ----- DefaultContentCreator#createNode(String name, String primaryNodeType, String[] mixinNodeTypes)-------//
 
     @Test
-    public void createNodeWithoutNameAndTwoInStack() throws RepositoryException {
+    void createNodeWithoutNameAndTwoInStack() throws RepositoryException {
         contentCreator.init(
                 createImportOptions(OVERWRITE_NODE | OVERWRITE_PROPERTIES | AUTO_CHECKOUT),
                 new HashMap<String, ContentReader>(),
@@ -322,7 +326,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createNodeWithoutProvidedNames() throws RepositoryException {
+    void createNodeWithoutProvidedNames() throws RepositoryException {
         @SuppressWarnings("unchecked")
         Deque<Node> nodesStack =
                 (Deque<Node>) ReflectionTools.getFieldWithReflection(contentCreator, "parentNodeStack", Deque.class);
@@ -342,7 +346,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createNodeWithOverwrite() throws RepositoryException {
+    void createNodeWithOverwrite() throws RepositoryException {
         final String newNodeName = uniqueId();
         final String propertyName = uniqueId();
         final String propertyValue = uniqueId();
@@ -372,7 +376,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void addMixinsToExistingNode() throws RepositoryException {
+    void addMixinsToExistingNode() throws RepositoryException {
         final String newNodeName = uniqueId();
         final String[] mixins = {"mix:versionable"};
         @SuppressWarnings("unchecked")
@@ -391,7 +395,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createNodeWithPrimaryType() throws RepositoryException {
+    void createNodeWithPrimaryType() throws RepositoryException {
         final String newNodeName = uniqueId();
         final List<String> createdNodes = new ArrayList<String>();
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
@@ -421,7 +425,7 @@ public class DefaultContentCreatorTest {
     // ----- DefaultContentCreator#createProperty(String name, int propertyType, String[] values)-------//
 
     @Test
-    public void propertyDoesntOverwritten() throws RepositoryException {
+    void propertyDoesntOverwritten() throws RepositoryException {
         final String newPropertyName = uniqueId();
         final String newPropertyValue = uniqueId();
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
@@ -436,7 +440,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createReferenceProperty() throws RepositoryException {
+    void createReferenceProperty() throws RepositoryException {
         final String propName = uniqueId();
         final String[] propValues = {uniqueId(), uniqueId()};
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
@@ -464,7 +468,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createDateProperty() throws RepositoryException {
+    void createDateProperty() throws RepositoryException {
         final String propName = "dateProp";
         final String[] propValues = {"2012-10-01T09:45:00.000+02:00", "2011-02-13T09:45:00.000+02:00"};
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
@@ -491,7 +495,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createUndefinedProperty() throws RepositoryException {
+    void createUndefinedProperty() throws RepositoryException {
         final String propName = uniqueId();
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
 
@@ -511,7 +515,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createOtherProperty() throws RepositoryException {
+    void createOtherProperty() throws RepositoryException {
         final String propName = uniqueId();
 
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
@@ -525,7 +529,7 @@ public class DefaultContentCreatorTest {
     // ------DefaultContentCreator#finishNode()------//
 
     @Test
-    public void finishNodeWithMultipleProperty() throws RepositoryException {
+    void finishNodeWithMultipleProperty() throws RepositoryException {
         final String propName = uniqueId();
         final String underTestNodeName = uniqueId();
         @SuppressWarnings("unchecked")
@@ -555,7 +559,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void finishNodeWithSingleProperty() throws RepositoryException {
+    void finishNodeWithSingleProperty() throws RepositoryException {
         final String propName = uniqueId();
         final String underTestNodeName = uniqueId();
         final ContentImportListener listener = mockery.mock(ContentImportListener.class);
@@ -581,7 +585,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void finishNodeWithoutProperties() throws RepositoryException {
+    void finishNodeWithoutProperties() throws RepositoryException {
         final String propName = uniqueId();
         final String underTestNodeName = uniqueId();
 
@@ -596,7 +600,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void finishNotReferenceableNode() throws RepositoryException {
+    void finishNotReferenceableNode() throws RepositoryException {
         final String propName = uniqueId();
         final String underTestNodeName = uniqueId();
 
@@ -612,7 +616,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithoutRestrictionsSpecified() throws RepositoryException {
+    void createAceWithoutRestrictionsSpecified() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -648,7 +652,7 @@ public class DefaultContentCreatorTest {
 
     @Deprecated
     @Test
-    public void createAceWithNonSpecificRestrictions() throws RepositoryException {
+    void createAceWithNonSpecificRestrictions() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -691,7 +695,7 @@ public class DefaultContentCreatorTest {
 
     @Deprecated
     @Test
-    public void createAceWithNullSpecificRestrictions() throws RepositoryException {
+    void createAceWithNullSpecificRestrictions() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -729,7 +733,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithSpecificRestrictions() throws RepositoryException {
+    void createAceWithSpecificRestrictions() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -772,7 +776,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithSpecificRestrictionsTwice() throws RepositoryException {
+    void createAceWithSpecificRestrictionsTwice() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -817,7 +821,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithNullPrivileges() throws RepositoryException {
+    void createAceWithNullPrivileges() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -835,7 +839,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithNullPrincipal() throws RepositoryException {
+    void createAceWithNullPrincipal() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -843,13 +847,16 @@ public class DefaultContentCreatorTest {
         contentCreator.createUser(userName, "Test", null);
 
         // try null principal
-        assertThrows("No principal found for id: null", RepositoryException.class, () -> {
-            contentCreator.createAce(
-                    null,
-                    new String[] {PrivilegeConstants.JCR_READ},
-                    new String[] {PrivilegeConstants.JCR_WRITE},
-                    null);
-        });
+        assertThrows(
+                RepositoryException.class,
+                () -> {
+                    contentCreator.createAce(
+                            null,
+                            new String[] {PrivilegeConstants.JCR_READ},
+                            new String[] {PrivilegeConstants.JCR_WRITE},
+                            null);
+                },
+                "No principal found for id: null");
 
         contentCreator.finishNode();
 
@@ -859,20 +866,23 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithInvalidPrincipal() throws RepositoryException {
+    void createAceWithInvalidPrincipal() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
         final String userName = uniqueId();
 
         // try non-existing principal
-        assertThrows(String.format("No principal found for id: %s", userName), RepositoryException.class, () -> {
-            contentCreator.createAce(
-                    userName,
-                    new String[] {PrivilegeConstants.JCR_READ},
-                    new String[] {PrivilegeConstants.JCR_WRITE},
-                    null);
-        });
+        assertThrows(
+                RepositoryException.class,
+                () -> {
+                    contentCreator.createAce(
+                            userName,
+                            new String[] {PrivilegeConstants.JCR_READ},
+                            new String[] {PrivilegeConstants.JCR_WRITE},
+                            null);
+                },
+                String.format("No principal found for id: %s", userName));
 
         contentCreator.finishNode();
 
@@ -882,7 +892,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByNull() throws RepositoryException {
+    void createAceWithOrderByNull() throws RepositoryException {
         createAceWithOrderBy(null);
     }
 
@@ -947,12 +957,12 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByEmpty() throws RepositoryException {
+    void createAceWithOrderByEmpty() throws RepositoryException {
         createAceWithOrderBy("");
     }
 
     @Test
-    public void createAceWithOrderByFirst() throws RepositoryException {
+    void createAceWithOrderByFirst() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1013,12 +1023,12 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByLast() throws RepositoryException {
+    void createAceWithOrderByLast() throws RepositoryException {
         createAceWithOrderBy("last");
     }
 
     @Test
-    public void createAceWithOrderByAfter() throws RepositoryException {
+    void createAceWithOrderByAfter() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1097,7 +1107,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByBefore() throws RepositoryException {
+    void createAceWithOrderByBefore() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1158,7 +1168,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByAfterInvalid() throws RepositoryException {
+    void createAceWithOrderByAfterInvalid() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1177,9 +1187,12 @@ public class DefaultContentCreatorTest {
                 AccessControlConstants.REP_ITEM_NAMES,
                 vals(session.getValueFactory(), PropertyType.NAME, "name1", "name2"))));
         list.add(writeLp);
-        assertThrows("No ACE was found for the specified principal: invalid", IllegalArgumentException.class, () -> {
-            contentCreator.createAce(userName, list, "after invalid");
-        });
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    contentCreator.createAce(userName, list, "after invalid");
+                },
+                "No ACE was found for the specified principal: invalid");
 
         contentCreator.finishNode();
 
@@ -1189,7 +1202,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByBeforeInvalid() throws RepositoryException {
+    void createAceWithOrderByBeforeInvalid() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1208,9 +1221,12 @@ public class DefaultContentCreatorTest {
                 AccessControlConstants.REP_ITEM_NAMES,
                 vals(session.getValueFactory(), PropertyType.NAME, "name1", "name2"))));
         list.add(writeLp);
-        assertThrows("No ACE was found for the specified principal: invalid", IllegalArgumentException.class, () -> {
-            contentCreator.createAce(userName, list, "before invalid");
-        });
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    contentCreator.createAce(userName, list, "before invalid");
+                },
+                "No ACE was found for the specified principal: invalid");
 
         contentCreator.finishNode();
 
@@ -1220,7 +1236,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByIndex() throws RepositoryException {
+    void createAceWithOrderByIndex() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1299,7 +1315,7 @@ public class DefaultContentCreatorTest {
     }
 
     @Test
-    public void createAceWithOrderByInvalid() throws RepositoryException {
+    void createAceWithOrderByInvalid() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1318,15 +1334,18 @@ public class DefaultContentCreatorTest {
                 AccessControlConstants.REP_ITEM_NAMES,
                 vals(session.getValueFactory(), PropertyType.NAME, "name1", "name2"))));
         list.add(writeLp);
-        assertThrows("Illegal value for the order parameter: invalid", IllegalArgumentException.class, () -> {
-            contentCreator.createAce(userName, list, "invalid");
-        });
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    contentCreator.createAce(userName, list, "invalid");
+                },
+                "Illegal value for the order parameter: invalid");
 
         contentCreator.finishNode();
     }
 
     @Test
-    public void createAceWithOrderByIndexTooLarge() throws RepositoryException {
+    void createAceWithOrderByIndexTooLarge() throws RepositoryException {
         contentCreator.init(createImportOptions(NO_OPTIONS), new HashMap<String, ContentReader>(), null, null);
         contentCreator.prepareParsing(parentNode, null);
 
@@ -1345,9 +1364,12 @@ public class DefaultContentCreatorTest {
                 AccessControlConstants.REP_ITEM_NAMES,
                 vals(session.getValueFactory(), PropertyType.NAME, "name1", "name2"))));
         list.add(writeLp);
-        assertThrows("Index value is too large: 100", IndexOutOfBoundsException.class, () -> {
-            contentCreator.createAce(userName, list, "100");
-        });
+        assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> {
+                    contentCreator.createAce(userName, list, "100");
+                },
+                "Index value is too large: 100");
 
         contentCreator.finishNode();
     }

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/ReflectionTools.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/ReflectionTools.java
@@ -23,7 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Reflection utilities to facilitate testing

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/SLING11203Test.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/SLING11203Test.java
@@ -29,14 +29,18 @@ import org.apache.sling.jcr.contentloader.internal.readers.OrderedJsonReader;
 import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
 import org.apache.sling.jcr.contentloader.internal.readers.ZipReader;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.Bundle;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -46,37 +50,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Testing content loader waiting for required content reader
  */
-public class SLING11203Test {
+@ExtendWith(SlingContextExtension.class)
+class SLING11203Test {
 
     protected org.slf4j.Logger logger = LoggerFactory.getLogger(getClass());
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private BundleContentLoaderListener bundleHelper;
 
-    @Rule
-    public TestRule watcher = new TestWatcher() {
+    @RegisterExtension
+    public LoggingTestWatcher watcher = new LoggingTestWatcher(logger);
 
-        /* (non-Javadoc)
-         * @see org.junit.rules.TestWatcher#starting(org.junit.runner.Description)
-         */
-        @Override
-        protected void starting(Description description) {
-            logger.info("Starting test: {}", description.getMethodName());
-        }
-
-        /* (non-Javadoc)
-         * @see org.junit.rules.TestWatcher#finished(org.junit.runner.Description)
-         */
-        @Override
-        protected void finished(Description description) {
-            logger.info("Finished test: {}", description.getMethodName());
-        }
-    };
-
-    @Before
-    public void prepareContentLoader() throws Exception {
+    @BeforeEach
+    void prepareContentLoader() {
         // NOTE: initially only the default set of content readers are registered
         context.registerInjectActivateService(JsonReader.class);
         context.registerInjectActivateService(OrderedJsonReader.class);
@@ -91,7 +78,7 @@ public class SLING11203Test {
     }
 
     @Test
-    public void loadContentWithoutDirectiveExpectedContentReaderRegistered() throws Exception {
+    void loadContentWithoutDirectiveExpectedContentReaderRegistered() throws Exception {
         loadContentWithDirective();
 
         // check node was not added during parsing the file
@@ -107,7 +94,7 @@ public class SLING11203Test {
     }
 
     @Test
-    public void loadContentWithDirectiveExpectedContentReaderRegisteredBeforeBundleLoaded() throws Exception {
+    void loadContentWithDirectiveExpectedContentReaderRegisteredBeforeBundleLoaded() throws Exception {
         // register the content reader that we require before registering the bundle
         registerCustomContentReader();
 
@@ -126,7 +113,7 @@ public class SLING11203Test {
     }
 
     @Test
-    public void loadContentWithDirectiveExpectedContentReaderRegisteredAfterBundleLoaded() throws Exception {
+    void loadContentWithDirectiveExpectedContentReaderRegisteredAfterBundleLoaded() throws Exception {
         loadContentWithDirective();
 
         // check node was not added during parsing the file
@@ -188,6 +175,44 @@ public class SLING11203Test {
         private SLING11203XmlReader() {
             super();
             activate();
+        }
+    }
+
+    /**
+     * Extension to wrap the test run with logging messages
+     */
+    static class LoggingTestWatcher implements AfterEachCallback, BeforeEachCallback {
+        private Logger logger;
+
+        public LoggingTestWatcher(Logger logger) {
+            this.logger = logger;
+        }
+
+        protected String uniqueTestName(ExtensionContext context) {
+            if (context.getRequiredTestMethod().getAnnotation(Test.class) != null) {
+                if (context.getRequiredTestMethod().getAnnotation(DisplayName.class) != null) {
+                    return String.format(
+                            "%s [%s]", context.getRequiredTestMethod().getName(), context.getDisplayName());
+                } else {
+                    return context.getRequiredTestMethod().getName();
+                }
+            } else {
+                return String.format("%s [%s]", context.getRequiredTestMethod().getName(), context.getDisplayName());
+            }
+        }
+
+        @Override
+        public void beforeEach(ExtensionContext context) throws Exception {
+            if (logger.isInfoEnabled()) {
+                logger.info("Starting test: {}", uniqueTestName(context));
+            }
+        }
+
+        @Override
+        public void afterEach(ExtensionContext context) throws Exception {
+            if (logger.isInfoEnabled()) {
+                logger.info("Finished test: {}", uniqueTestName(context));
+            }
         }
     }
 }

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/hc/BundleContentLoadedCheckTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/hc/BundleContentLoadedCheckTest.java
@@ -36,21 +36,22 @@ import org.apache.sling.jcr.contentloader.internal.readers.XmlReader;
 import org.apache.sling.jcr.contentloader.internal.readers.ZipReader;
 import org.apache.sling.testing.mock.osgi.MockBundle;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BundleContentLoadedCheckTest {
+@ExtendWith(SlingContextExtension.class)
+class BundleContentLoadedCheckTest {
 
-    @Rule
     public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
     private MockBundle bundle;
@@ -58,8 +59,8 @@ public class BundleContentLoadedCheckTest {
     private BundleContentLoader contentLoader;
     private BundleContentLoadedCheck check;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         bundle = BundleContentLoaderTest.newBundleWithInitialContent(context, "SLING-INF/libs/app;path:=/libs/app");
 
         // prepare content readers
@@ -126,13 +127,13 @@ public class BundleContentLoadedCheckTest {
     }
 
     @Test
-    public void testNotInstalled() {
+    void testNotInstalled() {
         Result result = check.execute();
         assertFalse(result.isOk());
     }
 
     @Test
-    public void testInstalled() {
+    void testInstalled() {
         contentLoader.registerBundle(context.resourceResolver().adaptTo(Session.class), bundle, false);
         Result result = check.execute();
         assertTrue(result.isOk());

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/JsonReaderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.sling.jcr.contentloader.internal;
+package org.apache.sling.jcr.contentloader.internal.readers;
 
 import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
@@ -35,18 +35,20 @@ import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonWriter;
 import org.apache.sling.jcr.contentloader.ContentCreator;
 import org.apache.sling.jcr.contentloader.LocalPrivilege;
-import org.apache.sling.jcr.contentloader.internal.readers.JsonReader;
 import org.jmock.Expectations;
 import org.jmock.Sequence;
-import org.jmock.integration.junit4.JUnitRuleMockery;
-import org.junit.Rule;
+import org.jmock.junit5.JUnit5Mockery;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class JsonReaderTest {
+class JsonReaderTest {
 
     protected JsonReader jsonReader;
 
-    @Rule
-    public final JUnitRuleMockery mockery = new JUnitRuleMockery();
+    @RegisterExtension
+    public final JUnit5Mockery mockery = new JUnit5Mockery();
 
     protected ContentCreator creator;
 
@@ -56,20 +58,20 @@ public class JsonReaderTest {
         this.jsonReader = new JsonReader();
     }
 
-    @org.junit.Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         setReader();
         this.creator = this.mockery.mock(ContentCreator.class);
         this.mySequence = this.mockery.sequence("my-sequence");
     }
 
-    @org.junit.After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() {
         this.jsonReader = null;
     }
 
-    @org.junit.Test
-    public void testEmptyObject() throws Exception {
+    @Test
+    void testEmptyObject() throws Exception {
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
@@ -83,8 +85,8 @@ public class JsonReaderTest {
         this.parse("");
     }
 
-    @org.junit.Test
-    public void testEmpty() throws IOException, RepositoryException {
+    @Test
+    void testEmpty() throws IOException, RepositoryException {
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
@@ -98,8 +100,8 @@ public class JsonReaderTest {
         this.parse("{}");
     }
 
-    @org.junit.Test
-    public void testDefaultPrimaryNodeTypeWithSurroundWhitespace() throws Exception {
+    @Test
+    void testDefaultPrimaryNodeTypeWithSurroundWhitespace() throws Exception {
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
@@ -114,8 +116,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testDefaultPrimaryNodeTypeWithoutEnclosingBracesWithSurroundWhitespace() throws Exception {
+    @Test
+    void testDefaultPrimaryNodeTypeWithoutEnclosingBracesWithSurroundWhitespace() throws Exception {
         this.mockery.checking(new Expectations() {
             {
                 allowing(creator).createNode(null, null, null);
@@ -130,8 +132,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testExplicitePrimaryNodeType() throws Exception {
+    @Test
+    void testExplicitePrimaryNodeType() throws Exception {
         final String type = "xyz:testType";
         String json = "{ \"jcr:primaryType\": \"" + type + "\" }";
 
@@ -148,8 +150,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testMixinNodeTypes1() throws Exception {
+    @Test
+    void testMixinNodeTypes1() throws Exception {
         final String[] mixins = new String[] {"xyz:mix1"};
         String json = "{ \"jcr:mixinTypes\": " + this.toJsonArray(mixins) + "}";
 
@@ -166,8 +168,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testMixinNodeTypes2() throws Exception {
+    @Test
+    void testMixinNodeTypes2() throws Exception {
         final String[] mixins = new String[] {"xyz:mix1", "abc:mix2"};
         String json = "{ \"jcr:mixinTypes\": " + this.toJsonArray(mixins) + "}";
 
@@ -184,8 +186,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesEmpty() throws Exception {
+    @Test
+    void testPropertiesEmpty() throws Exception {
         String json = "{ \"property\": \"\"}";
 
         this.mockery.checking(new Expectations() {
@@ -203,8 +205,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesSingleValue() throws Exception {
+    @Test
+    void testPropertiesSingleValue() throws Exception {
         String json = "{ \"p1\": \"v1\"}";
 
         this.mockery.checking(new Expectations() {
@@ -223,8 +225,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesSingleDateValue() throws Exception {
+    @Test
+    void testPropertiesSingleDateValue() throws Exception {
         String json = "{ \"p1\": \"2009-09-24T16:32:57.948-07:00\"}";
 
         this.mockery.checking(new Expectations() {
@@ -243,8 +245,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesTwoSingleValue() throws Exception {
+    @Test
+    void testPropertiesTwoSingleValue() throws Exception {
         String json = "{ \"p1\": \"v1\", \"p2\": \"v2\"}";
 
         this.mockery.checking(new Expectations() {
@@ -264,8 +266,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesMultiValue() throws Exception {
+    @Test
+    void testPropertiesMultiValue() throws Exception {
         String json = "{ \"p1\": [\"v1\"]}";
 
         this.mockery.checking(new Expectations() {
@@ -283,8 +285,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesMultiDateValue() throws Exception {
+    @Test
+    void testPropertiesMultiDateValue() throws Exception {
         String json = "{ \"p1\": [\"2009-09-24T16:32:57.948-07:00\"]}";
 
         this.mockery.checking(new Expectations() {
@@ -303,8 +305,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testPropertiesMultiValueEmpty() throws Exception {
+    @Test
+    void testPropertiesMultiValueEmpty() throws Exception {
         String json = "{ \"p1\": []}";
 
         this.mockery.checking(new Expectations() {
@@ -322,8 +324,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testChild() throws Exception {
+    @Test
+    void testChild() throws Exception {
         String json = "{ " + " \"c1\" : {}" + "}";
         this.mockery.checking(new Expectations() {
             {
@@ -342,8 +344,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testChildWithMixin() throws Exception {
+    @Test
+    void testChildWithMixin() throws Exception {
         String json = "{ " + " \"c1\" : {" + "\"jcr:mixinTypes\" : [\"xyz:TestType\"]" + "}" + "}";
         this.mockery.checking(new Expectations() {
             {
@@ -362,8 +364,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testTwoChildren() throws Exception {
+    @Test
+    void testTwoChildren() throws Exception {
         String json = "{ " + " \"c1\" : {}," + " \"c2\" : {}" + "}";
         this.mockery.checking(new Expectations() {
             {
@@ -386,8 +388,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testChildWithProperty() throws Exception {
+    @Test
+    void testChildWithProperty() throws Exception {
         String json = "{ " + " \"c1\" : {" + "      \"c1p1\" : \"v1\"" + "}" + "}";
         this.mockery.checking(new Expectations() {
             {
@@ -407,8 +409,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testCreateOnePrincipal() throws Exception {
+    @Test
+    void testCreateOnePrincipal() throws Exception {
         String json = "{\"security:principals\":{ " + "    \"name\" : \"username2\"," + "    \"password\" : \"pwd2\""
                 + "  }}";
         final LinkedHashMap<String, Object> map = new LinkedHashMap<String, Object>();
@@ -426,8 +428,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testCreatePrincipals() throws Exception {
+    @Test
+    void testCreatePrincipals() throws Exception {
         String json = "{\"security:principals\":[ " + "  { " + "    \"name\" : \"username1\","
                 + "    \"password\" : \"pwd1\"," + "    \"foo\" : \"bar\"" + "  }," + "  { "
                 + "    \"name\" : \"username2\"," + "    \"password\" : \"pwd2\"" + "  }," + "  { "
@@ -466,8 +468,8 @@ public class JsonReaderTest {
         return list;
     }
 
-    @org.junit.Test
-    public void testCreateAcl() throws Exception {
+    @Test
+    void testCreateAcl() throws Exception {
         String json = " { " + "\"security:acl\" : [ " + "  { " + "    \"principal\" : \"username1\","
                 + "    \"granted\" : [\"jcr:read\",\"jcr:write\"]," + "    \"denied\" : []" + "  }," + "  {"
                 + "    \"principal\" : \"groupname1\"," + "    \"granted\" : [\"jcr:read\",\"jcr:write\"]" + "  },"
@@ -502,8 +504,8 @@ public class JsonReaderTest {
         this.parse(json);
     }
 
-    @org.junit.Test
-    public void testCreateAclWithTickQuotes() throws Exception {
+    @Test
+    void testCreateAclWithTickQuotes() throws Exception {
         String json = " { " + "'security:acl' : [ " + "  { " + "    'principal' : 'username1',"
                 + "    'granted' : ['jcr:read','jcr:write']," + "    'denied' : []" + "  }," + "  {"
                 + "    'principal' : 'groupname1'," + "    'granted' : ['jcr:read','jcr:write']" + "  }," + "  {"

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/MockContentCreator.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/MockContentCreator.java
@@ -55,8 +55,6 @@ class MockContentCreator extends Stack<Map<String, Object>> implements ContentCr
 
     public List<MockContentCreator.FileDescription> filesCreated = new ArrayList<MockContentCreator.FileDescription>();
 
-    public MockContentCreator() {}
-
     public void createNode(String name, String primaryNodeType, String[] mixinNodeTypes) throws RepositoryException {
         Map<String, Object> map = new HashMap<>();
         map.put("name", name);
@@ -65,7 +63,9 @@ class MockContentCreator extends Stack<Map<String, Object>> implements ContentCr
         this.push(map);
     }
 
-    public void finishNode() throws RepositoryException {}
+    public void finishNode() throws RepositoryException {
+        // intentionally left empty
+    }
 
     protected void recordProperty(String name, Object value) {
         if (!isEmpty()) {
@@ -107,7 +107,9 @@ class MockContentCreator extends Stack<Map<String, Object>> implements ContentCr
     }
 
     public void createAce(String principal, String[] grantedPrivileges, String[] deniedPrivileges, String order)
-            throws RepositoryException {}
+            throws RepositoryException {
+        // intentionally left empty
+    }
 
     /*
      * (non-Javadoc)
@@ -118,6 +120,7 @@ class MockContentCreator extends Stack<Map<String, Object>> implements ContentCr
      * java.util.Map, java.util.Set)
      */
     @Override
+    @Deprecated
     public void createAce(
             String principal,
             String[] grantedPrivileges,
@@ -126,14 +129,22 @@ class MockContentCreator extends Stack<Map<String, Object>> implements ContentCr
             Map<String, Value> restrictions,
             Map<String, Value[]> mvRestrictions,
             Set<String> removedRestrictionNames)
-            throws RepositoryException {}
+            throws RepositoryException {
+        // intentionally left empty
+    }
 
     public void createGroup(String name, String[] members, Map<String, Object> extraProperties)
-            throws RepositoryException {}
+            throws RepositoryException {
+        // intentionally left empty
+    }
 
     public void createUser(String name, String password, Map<String, Object> extraProperties)
-            throws RepositoryException {}
+            throws RepositoryException {
+        // intentionally left empty
+    }
 
     @Override
-    public void finish() throws RepositoryException {}
+    public void finish() throws RepositoryException {
+        // intentionally left empty
+    }
 }

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReaderTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
  * - should work with all normal json cases,
  * - should work for specific ordered case
  */
-public class OrderedJsonReaderTest extends JsonReaderTest {
+class OrderedJsonReaderTest extends JsonReaderTest {
 
     @Override
     protected void setReader() {
@@ -34,7 +34,7 @@ public class OrderedJsonReaderTest extends JsonReaderTest {
     }
 
     @Test
-    public void testTwoOrderedChildren() throws Exception {
+    void testTwoOrderedChildren() throws Exception {
         String json = "{ " + " \"SLING:ordered\" : ["
                 + "{ \"SLING:name\": \"c1\"},"
                 + "{ \"SLING:name\": \"c2\"}"

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/OrderedJsonReaderTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.sling.jcr.contentloader.internal.readers;
 
-import org.apache.sling.jcr.contentloader.internal.JsonReaderTest;
 import org.jmock.Expectations;
+import org.junit.jupiter.api.Test;
 
 /**
  * testing specific ordered json import case:
@@ -33,7 +33,7 @@ public class OrderedJsonReaderTest extends JsonReaderTest {
         this.jsonReader = new OrderedJsonReader();
     }
 
-    @org.junit.Test
+    @Test
     public void testTwoOrderedChildren() throws Exception {
         String json = "{ " + " \"SLING:ordered\" : ["
                 + "{ \"SLING:name\": \"c1\"},"

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/XmlReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/XmlReaderTest.java
@@ -28,12 +28,17 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class XmlReaderTest extends TestCase {
+class XmlReaderTest {
 
     private XmlReader reader;
     private MockContentCreator creator;
@@ -41,40 +46,43 @@ public class XmlReaderTest extends TestCase {
     /**
      * Test the XmlReader with an XSLT transform.
      */
-    public void testXmlReader() throws Exception {
+    @Test
+    void testXmlReader() throws Exception {
         File file = new File("src/test/resources/reader/sample.xml");
         final URL testdata = file.toURI().toURL();
         reader.parse(testdata, creator);
-        assertEquals("Did not create expected number of nodes", 1, creator.size());
+        assertEquals(1, creator.size(), "Did not create expected number of nodes");
     }
 
     /**
      * Test inclusion of binary files.
      */
-    public void testCreateFile() throws Exception {
+    @Test
+    void testCreateFile() throws Exception {
         File input = new File("src/test/resources/reader/filesample.xml");
         final URL testdata = input.toURI().toURL();
         reader.parse(testdata, creator);
-        assertEquals("Did not create expected number of files", 2, creator.filesCreated.size());
+        assertEquals(2, creator.filesCreated.size(), "Did not create expected number of files");
         MockContentCreator.FileDescription file = creator.filesCreated.get(0);
         try {
             file.data.available();
-            TestCase.fail("Did not close inputstream");
+            fail("Did not close inputstream");
         } catch (IOException ignore) {
             // Expected
         }
-        assertEquals("mimeType mismatch", "application/test", file.mimeType);
+        assertEquals("application/test", file.mimeType, "mimeType mismatch");
         assertEquals(
-                "lastModified mismatch",
                 XmlReader.FileDescription.createDateFormat().parse("1977-06-01T07:00:00+0100"),
-                new Date(file.lastModified));
-        assertEquals("Could not read file", "This is a test file.", file.content);
+                new Date(file.lastModified),
+                "lastModified mismatch");
+        assertEquals("This is a test file.", file.content, "Could not read file");
     }
 
     /**
      * Test the properties and types were processed
      */
-    public void testCreateTypesAndProperties() throws Exception {
+    @Test
+    void testCreateTypesAndProperties() throws Exception {
         File input = new File("src/test/resources/reader/filesample.xml");
         final URL testdata = input.toURI().toURL();
         reader.parse(testdata, creator);
@@ -93,31 +101,30 @@ public class XmlReaderTest extends TestCase {
         assertNull(propsMap.get("multiPropName2"));
     }
 
-    public void testCreateFileWithNullLocation() throws Exception {
+    @Test
+    void testCreateFileWithNullLocation() throws Exception {
         File input = new File("src/test/resources/reader/filesample.xml");
-        final FileInputStream ins = new FileInputStream(input);
-        try {
+        try (final FileInputStream ins = new FileInputStream(input)) {
             reader.parse(ins, creator);
-            assertEquals("Created files when we shouldn't have", 0, creator.filesCreated.size());
-        } finally {
-            ins.close();
+            assertEquals(0, creator.filesCreated.size(), "Created files when we shouldn't have");
         }
     }
 
-    public void testUseOSLastModified() throws RepositoryException, IOException {
+    @Test
+    void testUseOSLastModified() throws RepositoryException, IOException {
         File input = new File("src/test/resources/reader/datefallbacksample.xml");
         final URL testdata = input.toURI().toURL();
         reader.parse(testdata, creator);
         File file = new File("src/test/resources/reader/testfile.txt");
         long originalLastModified = file.lastModified();
-        assertEquals("Did not create expected number of files", 1, creator.filesCreated.size());
+        assertEquals(1, creator.filesCreated.size(), "Did not create expected number of files");
         MockContentCreator.FileDescription fileDescription = creator.filesCreated.get(0);
         assertEquals(
-                "Did not pick up last modified date from file", originalLastModified, fileDescription.lastModified);
+                originalLastModified, fileDescription.lastModified, "Did not pick up last modified date from file");
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeEach
+    void setUp() {
         reader = new XmlReader();
         reader.activate();
         creator = new MockContentCreator();
@@ -130,43 +137,50 @@ public class XmlReaderTest extends TestCase {
         }
     }
 
-    public void testMalformedXmlUnexpectedPropertyElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedPropertyElement() throws Exception {
         malformedXmlTest(
                 "<property/>",
                 "XML file does not seem to contain valid content xml. Expected name element for property in : null");
     }
 
-    public void testMalformedXmlUnexpectedNameElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedNameElement() throws Exception {
         malformedXmlTest(
                 "<name></name>",
                 "XML file does not seem to contain valid content xml. Unexpected name element in : null");
     }
 
-    public void testMalformedXmlUnexpectedValueElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedValueElement() throws Exception {
         malformedXmlTest(
                 "<value></value>",
                 "XML file does not seem to contain valid content xml. Unexpected value element in : null");
     }
 
-    public void testMalformedXmlUnexpectedValuesElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedValuesElement() throws Exception {
         malformedXmlTest(
                 "<values></values>",
                 "XML file does not seem to contain valid content xml. Unexpected values element in : null");
     }
 
-    public void testMalformedXmlUnexpectedTypeElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedTypeElement() throws Exception {
         malformedXmlTest(
                 "<type></type>",
                 "XML file does not seem to contain valid content xml. Unexpected type element in : null");
     }
 
-    public void testMalformedXmlUnexpectedPrimaryNodeTypeElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedPrimaryNodeTypeElement() throws Exception {
         malformedXmlTest(
                 "<primaryNodeType></primaryNodeType>",
                 "Element is not allowed at this location: primaryNodeType in null");
     }
 
-    public void testMalformedXmlUnexpectedMixinNodeTypeElement() throws Exception {
+    @Test
+    void testMalformedXmlUnexpectedMixinNodeTypeElement() throws Exception {
         malformedXmlTest(
                 "<mixinNodeType></mixinNodeType>", "Element is not allowed at this location: mixinNodeType in null");
     }

--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReaderTest.java
@@ -32,25 +32,26 @@ import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
-public class ZipReaderTest {
+class ZipReaderTest {
 
     private ZipReader reader;
     private MockContentCreator creator;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() {
         reader = new ZipReader();
         ZipReader.Config config = new ZipReader.Config() {
 
@@ -114,7 +115,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void noViolations() throws Exception {
+    void noViolations() throws Exception {
         // generate a zip
         byte[] zipBytes = generateZip(zipOut -> {
             ZipEntry entry = new ZipEntry("entry");
@@ -131,7 +132,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void fromUrlNoViolations() throws Exception {
+    void fromUrlNoViolations() throws Exception {
         // generate a zip
         byte[] zipBytes = generateZip(zipOut -> {
             ZipEntry entry = new ZipEntry("entry");
@@ -155,7 +156,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void totalEntryCountExceeded() throws Exception {
+    void totalEntryCountExceeded() throws Exception {
         // generate a zip with too many entries
         byte[] zipBytes = generateZip(zipOut -> {
             for (int i = 0; i < 6; i++) {
@@ -174,7 +175,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void totalSizeExceeded() throws Exception {
+    void totalSizeExceeded() throws Exception {
         // generate a zip with too many bytes
         byte[] zipBytes = generateZip(zipOut -> {
             ZipEntry entry = new ZipEntry("entry");
@@ -192,7 +193,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void compressionRatioExceed() throws Exception {
+    void compressionRatioExceed() throws Exception {
         // generate a zip with too high if a compression ratio
         byte[] zipBytes = generateZip(zipOut -> {
             ZipEntry entry = new ZipEntry("entry");
@@ -214,7 +215,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void createTempFile() throws Exception {
+    void createTempFile() throws Exception {
         File tempFile = null;
         try {
             tempFile = ZipReader.createTempFile();
@@ -227,20 +228,18 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void createTempFileForceNotUnix() throws Exception {
-        doWorkAsNotUnix(() -> {
-            createTempFile();
-        });
-    }
-
-    @Test(expected = org.junit.Test.None.class)
-    public void removeTempFileNull() throws Exception {
-        // should silently do nothing
-        ZipReader.removeTempFile(null);
+    void createTempFileForceNotUnix() throws Exception {
+        doWorkAsNotUnix(this::createTempFile);
     }
 
     @Test
-    public void removeTempFile() throws Exception {
+    void removeTempFileNull() {
+        // should silently do nothing
+        assertDoesNotThrow(() -> ZipReader.removeTempFile(null));
+    }
+
+    @Test
+    void removeTempFile() throws Exception {
         File tempFile = ZipReader.createTempFile();
         assertNotNull(tempFile);
         ZipReader.removeTempFile(tempFile);
@@ -248,7 +247,7 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void removeTempFileLogWarningOnIOException() throws Exception {
+    void removeTempFileLogWarningOnIOException() throws Exception {
         File tempFile = null;
         try {
             final File finalTempFile = ZipReader.createTempFile();
@@ -260,9 +259,9 @@ public class ZipReaderTest {
 
                 String err = doWorkWithCapturedSystemErr(() -> ZipReader.removeTempFile(finalTempFile));
                 assertTrue(
-                        "Expected warning logged about IOException wile removing the temp file",
                         err.contains(
-                                "WARN org.apache.sling.jcr.contentloader.internal.readers.ZipReader - Failed to remove the temp file"));
+                                "WARN org.apache.sling.jcr.contentloader.internal.readers.ZipReader - Failed to remove the temp file"),
+                        "Expected warning logged about IOException wile removing the temp file");
             }
         } finally {
             ZipReader.removeTempFile(tempFile);
@@ -273,14 +272,14 @@ public class ZipReaderTest {
     }
 
     @Test
-    public void createTempFileIOExceptionOnSetReadFailure() throws Exception {
+    void createTempFileIOExceptionOnSetReadFailure() throws Exception {
         final File fileMock = Mockito.mock(File.class);
         Mockito.when(fileMock.setReadable(true, true)).thenReturn(false);
         createTempFileIOException(fileMock, "Failed to set the temp file as readable");
     }
 
     @Test
-    public void createTempFileIOExceptionOnSetWriteFailure() throws Exception {
+    void createTempFileIOExceptionOnSetWriteFailure() throws Exception {
         final File fileMock = Mockito.mock(File.class);
         Mockito.when(fileMock.setReadable(true, true)).thenReturn(true);
         Mockito.when(fileMock.setWritable(true, true)).thenReturn(false);
@@ -306,7 +305,7 @@ public class ZipReaderTest {
 
             try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class); ) {
                 filesMock.when(() -> Files.createTempFile("zipentry", ".tmp")).thenReturn(pathMock);
-                IOException ioe = assertThrows(IOException.class, () -> ZipReader.createTempFile());
+                IOException ioe = assertThrows(IOException.class, ZipReader::createTempFile);
                 assertEquals(expectedMsg, ioe.getMessage());
             }
         });
@@ -326,7 +325,7 @@ public class ZipReaderTest {
      */
     static void doWorkAsNotUnix(RunnableWithExceptions worker) throws Exception {
         try (MockedStatic<ZipReader> zipReaderMock = Mockito.mockStatic(ZipReader.class, CALLS_REAL_METHODS); ) {
-            zipReaderMock.when(() -> ZipReader.isOsUnix()).thenReturn(false);
+            zipReaderMock.when(ZipReader::isOsUnix).thenReturn(false);
 
             // do the work
             worker.run();

--- a/src/test/java/org/apache/sling/jcr/contentloader/it/SLING11713InitialContentIT.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/it/SLING11713InitialContentIT.java
@@ -263,7 +263,7 @@ public class SLING11713InitialContentIT extends ContentloaderTestSupport {
         assertNotNull(storedPrivileges);
         assertEquals(expectedPrivilegeNames.length, storedPrivileges.length);
         Set<String> privilegeNamesSet =
-                Stream.of(storedPrivileges).map(item -> item.getName()).collect(Collectors.toSet());
+                Stream.of(storedPrivileges).map(Privilege::getName).collect(Collectors.toSet());
         for (String pn : expectedPrivilegeNames) {
             assertTrue("Expecting privilege: " + pn, privilegeNamesSet.contains(pn));
         }


### PR DESCRIPTION
Migrate to junit 5 where possible.

NOTE: the paxexam based integration tests must stay on junit4 for now (use junit-vintage-engine)