### PR TITLE
SLING-13173 - Overly broad mocking of Files.class can lead to test failures

### DIFF
--- a/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReaderTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentloader/internal/readers/ZipReaderTest.java
@@ -252,7 +252,7 @@ class ZipReaderTest {
         try {
             final File finalTempFile = ZipReader.createTempFile();
             tempFile = finalTempFile;
-            try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class); ) {
+            try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class, CALLS_REAL_METHODS); ) {
                 filesMock
                         .when(() -> Files.delete(finalTempFile.toPath()))
                         .thenThrow(new IOException("simulating ioexception during delete"));
@@ -303,7 +303,7 @@ class ZipReaderTest {
                         }
                     });
 
-            try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class); ) {
+            try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class, CALLS_REAL_METHODS); ) {
                 filesMock.when(() -> Files.createTempFile("zipentry", ".tmp")).thenReturn(pathMock);
                 IOException ioe = assertThrows(IOException.class, ZipReader::createTempFile);
                 assertEquals(expectedMsg, ioe.getMessage());


### PR DESCRIPTION
Add the CALLS_REAL_METHOD modifier when mocking Files.class . This makes mocking more precise and prevents unexpected method calls from failing.